### PR TITLE
feat(timetable): preload and cache cohorts' timetables and subs

### DIFF
--- a/src/database/timetable-loader.ts
+++ b/src/database/timetable-loader.ts
@@ -1,0 +1,170 @@
+import { and, eq, gte, inArray, sql } from 'drizzle-orm';
+import { db } from '~/database';
+import {
+  classroom,
+  cohort,
+  dayDefinition,
+  lesson,
+  lessonCohortMTM,
+  period,
+  subject,
+  substitution,
+  substitutionLessonMTM,
+  teacher,
+} from '~/database/schema/timetable';
+
+type LessonRow = typeof lesson.$inferSelect;
+type SubjectRow = typeof subject.$inferSelect;
+type DayRow = typeof dayDefinition.$inferSelect;
+type PeriodRow = typeof period.$inferSelect;
+type TeacherRow = typeof teacher.$inferSelect;
+type ClassroomRow = typeof classroom.$inferSelect;
+type SubstitutionRow = typeof substitution.$inferSelect;
+
+export async function loadEnrichedLessonsForCohort(cohortId: string) {
+  const lessonRows = (await db
+    .select({ lesson })
+    .from(lesson)
+    .innerJoin(lessonCohortMTM, eq(lesson.id, lessonCohortMTM.lessonId))
+    .where(eq(lessonCohortMTM.cohortId, cohortId))) as { lesson: LessonRow }[];
+
+  const lessons: LessonRow[] = lessonRows.map((r) => r.lesson);
+
+  if (lessons.length === 0) {
+    return [];
+  }
+
+  const subjectIds = Array.from(new Set(lessons.map((l) => l.subjectId)));
+  const dayIds = Array.from(new Set(lessons.map((l) => l.dayDefinitionId)));
+  const periodIds = Array.from(new Set(lessons.map((l) => l.periodId)));
+  const teacherIds = Array.from(
+    new Set(
+      lessons.flatMap((l) => (Array.isArray(l.teacherIds) ? l.teacherIds : []))
+    )
+  );
+  const classroomIds = Array.from(
+    new Set(
+      lessons.flatMap((l) =>
+        Array.isArray(l.classroomIds) ? l.classroomIds : []
+      )
+    )
+  );
+
+  const [subjects, days, periods, teachers, classrooms] = await Promise.all([
+    subjectIds.length
+      ? (db
+          .select()
+          .from(subject)
+          .where(inArray(subject.id, subjectIds)) as Promise<SubjectRow[]>)
+      : Promise.resolve([] as SubjectRow[]),
+    dayIds.length
+      ? (db
+          .select()
+          .from(dayDefinition)
+          .where(inArray(dayDefinition.id, dayIds)) as Promise<DayRow[]>)
+      : Promise.resolve([] as DayRow[]),
+    periodIds.length
+      ? (db
+          .select()
+          .from(period)
+          .where(inArray(period.id, periodIds)) as Promise<PeriodRow[]>)
+      : Promise.resolve([] as PeriodRow[]),
+    teacherIds.length
+      ? (db
+          .select()
+          .from(teacher)
+          .where(inArray(teacher.id, teacherIds)) as Promise<TeacherRow[]>)
+      : Promise.resolve([] as TeacherRow[]),
+    classroomIds.length
+      ? (db
+          .select()
+          .from(classroom)
+          .where(inArray(classroom.id, classroomIds)) as Promise<
+          ClassroomRow[]
+        >)
+      : Promise.resolve([] as ClassroomRow[]),
+  ]);
+
+  const subjMap = new Map(subjects.map((s) => [s.id, s] as const));
+  const dayMap = new Map(days.map((d) => [d.id, d] as const));
+  const periodMap = new Map(periods.map((p) => [p.id, p] as const));
+  const teacherMap = new Map(teachers.map((t) => [t.id, t] as const));
+  const classroomMap = new Map(classrooms.map((cr) => [cr.id, cr] as const));
+
+  const enriched = lessons.map((l) => {
+    const tIds = (Array.isArray(l.teacherIds) ? l.teacherIds : []) as string[];
+    const cIds = (
+      Array.isArray(l.classroomIds) ? l.classroomIds : []
+    ) as string[];
+
+    return {
+      classrooms: cIds
+        .map((id) => classroomMap.get(id))
+        .filter((cr): cr is ClassroomRow => Boolean(cr))
+        .map((cr) => ({ id: cr.id, name: cr.name, short: cr.short })),
+      day: dayMap.get(l.dayDefinitionId) ?? null,
+      id: l.id,
+      period: (() => {
+        const p = periodMap.get(l.periodId);
+        return p
+          ? {
+              endTime: String(p.endTime),
+              id: p.id,
+              period: p.period,
+              startTime: String(p.startTime),
+            }
+          : null;
+      })(),
+      periodsPerWeek: l.periodsPerWeek,
+      subject: (() => {
+        const s = subjMap.get(l.subjectId);
+        return s ? { id: s.id, name: s.name, short: s.short } : null;
+      })(),
+      teachers: tIds
+        .map((id) => teacherMap.get(id))
+        .filter((t): t is TeacherRow => Boolean(t))
+        .map((t) => ({
+          id: t.id,
+          name: `${t.firstName} ${t.lastName}`,
+          short: t.short,
+        })),
+      termDefinitionId: l.termDefinitionId,
+      weeksDefinitionId: l.weeksDefinitionId,
+    };
+  });
+
+  return enriched;
+}
+
+export async function loadSubstitutionsForCohort(cohortId: string) {
+  const today = new Date().toISOString().split('T')[0];
+
+  const substitutions = (await db
+    .select({
+      lessons: sql<string[]>`COALESCE(
+        ARRAY_AGG(${substitutionLessonMTM.lessonId}) FILTER (WHERE ${substitutionLessonMTM.lessonId} IS NOT NULL),
+        ARRAY[]::text[]
+      )`.as('lessons'),
+      substitution,
+      teacher,
+    })
+    .from(substitution)
+    .leftJoin(teacher, eq(substitution.substituter, teacher.id))
+    .leftJoin(
+      substitutionLessonMTM,
+      eq(substitution.id, substitutionLessonMTM.substitutionId)
+    )
+    .leftJoin(lesson, eq(substitutionLessonMTM.lessonId, lesson.id))
+    .leftJoin(lessonCohortMTM, eq(lesson.id, lessonCohortMTM.lessonId))
+    .leftJoin(cohort, eq(lessonCohortMTM.cohortId, cohort.id))
+    .where(
+      and(gte(substitution.date, today as string), eq(cohort.id, cohortId))
+    )
+    .groupBy(substitution.id, teacher.id)) as Array<{
+    lessons: string[];
+    substitution: SubstitutionRow;
+    teacher: TeacherRow | null;
+  }>;
+
+  return substitutions;
+}

--- a/src/routes/timetable/lesson/index.ts
+++ b/src/routes/timetable/lesson/index.ts
@@ -1,18 +1,11 @@
-import { eq, inArray } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
 import { StatusCodes } from 'http-status-codes';
 import { db } from '~/database';
-import {
-  classroom,
-  cohort,
-  dayDefinition,
-  lesson,
-  lessonCohortMTM,
-  period,
-  subject,
-  teacher,
-} from '~/database/schema/timetable';
+import { cohort } from '~/database/schema/timetable';
+import { loadEnrichedLessonsForCohort } from '~/database/timetable-loader';
 import type { SuccessResponse } from '~/utils/globals';
+import timetableCache from '~/utils/timetable-cache';
 import { timetableFactory } from '../_factory';
 
 export const getLessonsForCohort = timetableFactory.createHandlers(
@@ -35,105 +28,15 @@ export const getLessonsForCohort = timetableFactory.createHandlers(
         message: 'Cohort not found',
       });
     }
-
-    const lessonRows = await db
-      .select({ lesson })
-      .from(lesson)
-      .innerJoin(lessonCohortMTM, eq(lesson.id, lessonCohortMTM.lessonId))
-      .where(eq(lessonCohortMTM.cohortId, cohortId));
-
-    const lessons = lessonRows.map((r) => r.lesson);
-
-    if (lessons.length === 0) {
-      return c.json<SuccessResponse>({ data: [], success: true });
+    // Try cache first
+    const cached = timetableCache.getCachedLessonsForCohort(cohortId);
+    if (cached) {
+      return c.json<SuccessResponse>({ data: cached, success: true });
     }
 
-    const subjectIds = Array.from(new Set(lessons.map((l) => l.subjectId)));
-    const dayIds = Array.from(new Set(lessons.map((l) => l.dayDefinitionId)));
-    const periodIds = Array.from(new Set(lessons.map((l) => l.periodId)));
-    const teacherIds = Array.from(
-      new Set(
-        lessons.flatMap((l) =>
-          Array.isArray(l.teacherIds) ? l.teacherIds : []
-        )
-      )
-    );
-    const classroomIds = Array.from(
-      new Set(
-        lessons.flatMap((l) =>
-          Array.isArray(l.classroomIds) ? l.classroomIds : []
-        )
-      )
-    );
-
-    const [subjects, days, periods, teachers, classrooms] = await Promise.all([
-      db.select().from(subject).where(inArray(subject.id, subjectIds)),
-      db.select().from(dayDefinition).where(inArray(dayDefinition.id, dayIds)),
-      db.select().from(period).where(inArray(period.id, periodIds)),
-      teacherIds.length
-        ? db.select().from(teacher).where(inArray(teacher.id, teacherIds))
-        : Promise.resolve([] as (typeof teacher.$inferSelect)[]),
-      classroomIds.length
-        ? db.select().from(classroom).where(inArray(classroom.id, classroomIds))
-        : Promise.resolve([] as (typeof classroom.$inferSelect)[]),
-    ]);
-
-    const subjMap = new Map(subjects.map((s) => [s.id, s] as const));
-    const dayMap = new Map(days.map((d) => [d.id, d] as const));
-    const periodMap = new Map(periods.map((p) => [p.id, p] as const));
-    const teacherMap = new Map(teachers.map((t) => [t.id, t] as const));
-    const classroomMap = new Map(classrooms.map((cr) => [cr.id, cr] as const));
-
-    const enriched = lessons.map((l) => {
-      const tIds = (
-        Array.isArray(l.teacherIds) ? l.teacherIds : []
-      ) as string[];
-      const cIds = (
-        Array.isArray(l.classroomIds) ? l.classroomIds : []
-      ) as string[];
-
-      return {
-        classrooms: cIds
-          .map((id) => classroomMap.get(id))
-          .filter(Boolean)
-          .map((cr) => ({
-            id: (cr as (typeof classrooms)[number]).id,
-            name: (cr as (typeof classrooms)[number]).name,
-            short: (cr as (typeof classrooms)[number]).short,
-          })),
-        day: (() => {
-          const d = dayMap.get(l.dayDefinitionId);
-          return d;
-        })(),
-        id: l.id,
-        period: (() => {
-          const p = periodMap.get(l.periodId);
-          return p
-            ? {
-                endTime: String(p.endTime),
-                id: p.id,
-                period: p.period,
-                startTime: String(p.startTime),
-              }
-            : null;
-        })(),
-        periodsPerWeek: l.periodsPerWeek,
-        subject: (() => {
-          const s = subjMap.get(l.subjectId);
-          return s ? { id: s.id, name: s.name, short: s.short } : null;
-        })(),
-        teachers: tIds
-          .map((id) => teacherMap.get(id))
-          .filter(Boolean)
-          .map((t) => ({
-            id: (t as (typeof teachers)[number]).id,
-            name: `${(t as (typeof teachers)[number]).firstName} ${(t as (typeof teachers)[number]).lastName}`,
-            short: (t as (typeof teachers)[number]).short,
-          })),
-        termDefinitionId: l.termDefinitionId,
-        weeksDefinitionId: l.weeksDefinitionId,
-      };
-    });
+    const enriched = await loadEnrichedLessonsForCohort(cohortId);
+    // set cache
+    timetableCache.setLessonsForCohort(cohortId, enriched);
 
     return c.json<SuccessResponse>({ data: enriched, success: true });
   }

--- a/src/utils/timetable-cache.ts
+++ b/src/utils/timetable-cache.ts
@@ -1,0 +1,246 @@
+import { getLogger } from '@logtape/logtape';
+import { db } from '~/database';
+import { cohort } from '~/database/schema/timetable';
+import {
+  loadEnrichedLessonsForCohort,
+  loadSubstitutionsForCohort,
+} from '~/database/timetable-loader';
+import { registerMqttHandler } from '~/mqtt/client';
+
+const logger = getLogger(['chronos', 'timetable', 'cache']);
+
+type LessonsValue = Awaited<ReturnType<typeof loadEnrichedLessonsForCohort>>;
+type SubstitutionsValue = Awaited<
+  ReturnType<typeof loadSubstitutionsForCohort>
+>;
+
+type CohortCacheValue = {
+  lessons?: LessonsValue;
+  substitutions?: SubstitutionsValue;
+  loadedAt: number;
+};
+
+const CACHE_TTL_MS = Number(process.env.TIMETABLE_CACHE_TTL_MS ?? 30_000);
+
+const map = new Map<string, CohortCacheValue>();
+const inFlight = new Map<string, Promise<void>>();
+
+// metrics
+const metrics = {
+  hits: 0,
+  invalidations: 0,
+  misses: 0,
+  preload: 0,
+  refreshes: 0,
+};
+
+const now = () => Date.now();
+
+export function getCachedLessonsForCohort(
+  cohortId: string
+): LessonsValue | null {
+  const entry = map.get(cohortId);
+  if (!entry) {
+    return null;
+  }
+  if (!entry.lessons) {
+    return null;
+  }
+  if (now() - entry.loadedAt > CACHE_TTL_MS) {
+    return null;
+  }
+  metrics.hits += 1;
+  return entry.lessons;
+}
+
+export function setLessonsForCohort(cohortId: string, lessons: LessonsValue) {
+  const existing = map.get(cohortId) ?? { loadedAt: now() };
+  existing.lessons = lessons;
+  existing.loadedAt = now();
+  map.set(cohortId, existing);
+}
+
+export function getCachedSubstitutionsForCohort(
+  cohortId: string
+): SubstitutionsValue | null {
+  const entry = map.get(cohortId);
+  if (!entry) {
+    return null;
+  }
+  if (!entry.substitutions) {
+    return null;
+  }
+  if (now() - entry.loadedAt > CACHE_TTL_MS) {
+    return null;
+  }
+  metrics.hits += 1;
+  return entry.substitutions;
+}
+
+export function setSubstitutionsForCohort(
+  cohortId: string,
+  substitutions: SubstitutionsValue
+) {
+  const existing = map.get(cohortId) ?? { loadedAt: now() };
+  existing.substitutions = substitutions;
+  existing.loadedAt = now();
+  map.set(cohortId, existing);
+}
+
+export function invalidateCohort(cohortId: string) {
+  map.delete(cohortId);
+  metrics.invalidations += 1;
+}
+
+const PRELOAD_CONCURRENCY = 10;
+
+export async function preloadAllCohorts() {
+  logger.info('Preloading all cohorts into timetable cache');
+  const cohortIds = await db
+    .select({ id: cohort.id })
+    .from(cohort)
+    .then((rows: { id: string }[]) => rows.map((r) => r.id));
+
+  for (let i = 0; i < cohortIds.length; i += PRELOAD_CONCURRENCY) {
+    const batch = cohortIds.slice(i, i + PRELOAD_CONCURRENCY);
+    await Promise.all(
+      batch.map(async (id: string) => {
+        try {
+          const lessons = await loadEnrichedLessonsForCohort(id);
+          setLessonsForCohort(id, lessons);
+        } catch (err) {
+          logger.warn('Failed to preload lessons for cohort', { err, id });
+        }
+        try {
+          const subs = await loadSubstitutionsForCohort(id);
+          setSubstitutionsForCohort(id, subs);
+        } catch (err) {
+          logger.warn('Failed to preload substitutions for cohort', {
+            err,
+            id,
+          });
+        }
+        metrics.preload += 1;
+      })
+    );
+  }
+
+  logger.info('Preload complete', { count: cohortIds.length });
+}
+
+export async function initializeTimetableCache(opts?: { preload?: boolean }) {
+  if (opts?.preload) {
+    await preloadAllCohorts();
+  }
+  // Start background refresh loop
+  startBackgroundRefresh();
+}
+
+// Background refresh
+const REFRESH_INTERVAL_MS = Number(
+  process.env.TIMETABLE_CACHE_REFRESH_MS ?? 60_000
+);
+let refreshInterval: ReturnType<typeof setInterval> | null = null;
+
+function refreshCohort(cohortId: string) {
+  if (inFlight.has(cohortId)) {
+    return;
+  }
+  const p = (async () => {
+    try {
+      metrics.refreshes += 1;
+      try {
+        const lessons = await loadEnrichedLessonsForCohort(cohortId);
+        if (lessons) {
+          setLessonsForCohort(cohortId, lessons);
+        }
+      } catch (e) {
+        logger.warn('background refresh lessons failed', { cohortId, e });
+      }
+
+      try {
+        const subs = await loadSubstitutionsForCohort(cohortId);
+        if (subs) {
+          setSubstitutionsForCohort(cohortId, subs);
+        }
+      } catch (e) {
+        logger.warn('background refresh subs failed', { cohortId, e });
+      }
+    } finally {
+      inFlight.delete(cohortId);
+    }
+  })();
+  inFlight.set(cohortId, p);
+  return p;
+}
+
+export function startBackgroundRefresh() {
+  if (refreshInterval) {
+    return;
+  }
+  refreshInterval = setInterval(() => {
+    try {
+      for (const [cohortId, entry] of map.entries()) {
+        if (now() - entry.loadedAt > CACHE_TTL_MS) {
+          const p = refreshCohort(cohortId);
+          if (p) {
+            p.catch(() => {
+              /* ignore refresh errors */
+            });
+          }
+        }
+      }
+    } catch (err) {
+      logger.warn('background refresh loop failed', { err });
+    }
+  }, REFRESH_INTERVAL_MS);
+}
+
+export function stopBackgroundRefresh() {
+  if (refreshInterval) {
+    clearInterval(refreshInterval);
+    refreshInterval = null;
+  }
+}
+
+// MQTT invalidation handling
+registerMqttHandler('chronos/timetable/invalidate', async (_topic, payload) => {
+  try {
+    const msg = JSON.parse(payload.toString()) as {
+      cohortIds?: string[];
+      cohortId?: string;
+      refresh?: boolean;
+    };
+    const ids = msg.cohortIds ?? (msg.cohortId ? [msg.cohortId] : []);
+    if (!ids.length) {
+      return;
+    }
+    for (const id of ids) {
+      if (msg.refresh) {
+        await refreshCohort(id);
+      } else {
+        invalidateCohort(id);
+      }
+    }
+  } catch (err) {
+    logger.warn('invalid mqtt invalidation payload', { err });
+  }
+});
+
+export function getMetrics() {
+  return { ...metrics };
+}
+
+export function stopTimetableCache() {
+  stopBackgroundRefresh();
+}
+
+export default {
+  getCachedLessonsForCohort,
+  getCachedSubstitutionsForCohort,
+  initializeTimetableCache,
+  invalidateCohort,
+  preloadAllCohorts,
+  setLessonsForCohort,
+  setSubstitutionsForCohort,
+};


### PR DESCRIPTION
- In-memory cache for cohorts' timetables and substitutions (preload + TTL + background refresh).
- Shared DB loaders to build "enriched" lesson objects and substitution aggregates.
- Cross-instance invalidation via MQTT topic chronos/timetable/invalidate.
- Startup wiring: preload on boot and clean shutdown.