### PR TITLE
add .env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+CHRONOS_LOG_LEVEL=debug
+CHRONOS_BASE_URL=http://localhost:3000
+CHRONOS_DATABASE_URL=postgresql://postgres:postgres@db:5432/postgres
+# --------------------------------------------------
+# | You have to change every value below this line |
+# --------------------------------------------------
+CHRONOS_AUTH_SECRET=FILL_ME_IN
+CHRONOS_ADMIN_EMAIL=your.email.here@petrik.hu
+CHRONOS_ENTRA_TENANT_ID=FILL_ME_IN
+CHRONOS_ENTRA_CLIENT_ID=FILL_ME_IN
+CHRONOS_ENTRA_CLIENT_SECRET=FILL_ME_IN


### PR DESCRIPTION
I added a .env example so we don't have to go to the wiki every time we want to set up the project.