### PR TITLE
Add filcExt OpenAPI extensions and Ktor binding schemas

### DIFF
--- a/apps/chronos/src/routes/cohort/index.ts
+++ b/apps/chronos/src/routes/cohort/index.ts
@@ -4,6 +4,7 @@ import type { SuccessResponse } from '#_types/globals';
 import { db } from '#database';
 import { cohort } from '#database/schema/timetable';
 import { cohortFactory } from '#routes/cohort/_factory';
+import { filcExt } from '#utils/openapi';
 import { createSelectSchema } from '#utils/zod';
 
 const listCohortsResponseSchema = z.object({
@@ -13,6 +14,7 @@ const listCohortsResponseSchema = z.object({
 
 export const listCohorts = cohortFactory.createHandlers(
   describeRoute({
+    ...filcExt('Cohort', '@listof Cohort'),
     description: 'List all cohorts',
     responses: {
       200: {

--- a/apps/chronos/src/routes/doorlock/cards.ts
+++ b/apps/chronos/src/routes/doorlock/cards.ts
@@ -18,6 +18,7 @@ import {
   replaceCardDevices,
 } from '#utils/doorlock/cards';
 import { syncDevicesByIds } from '#utils/doorlock/device-sync';
+import { filcExt } from '#utils/openapi';
 import { createSelectSchema } from '#utils/zod';
 import { doorlockFactory } from './_factory';
 
@@ -97,6 +98,11 @@ const assertCardExists = (cardRecord?: DoorlockCardWithRelations | null) => {
 
 export const listCardsRoute = doorlockFactory.createHandlers(
   describeRoute({
+    ...filcExt(
+      'Doorlock',
+      '@unit CardListResponse @field(.cards, List<Card>)',
+      true
+    ),
     description: 'List all access cards',
     responses: {
       200: {
@@ -124,6 +130,11 @@ export const listCardsRoute = doorlockFactory.createHandlers(
 
 export const listDoorlockUsersRoute = doorlockFactory.createHandlers(
   describeRoute({
+    ...filcExt(
+      'Doorlock',
+      '@unit DoorlockUserListResponse @field(.users, List<DoorlockUser>)',
+      true
+    ),
     description: 'List users eligible for card ownership',
     responses: {
       200: {
@@ -159,6 +170,7 @@ export const listDoorlockUsersRoute = doorlockFactory.createHandlers(
 
 export const createCardRoute = doorlockFactory.createHandlers(
   describeRoute({
+    ...filcExt('Doorlock', '@unit CardResponse @field(.card, Card)', true),
     description: 'Create a new access card',
     requestBody: {
       content: {
@@ -242,6 +254,7 @@ export const createCardRoute = doorlockFactory.createHandlers(
 
 export const updateCardRoute = doorlockFactory.createHandlers(
   describeRoute({
+    ...filcExt('Doorlock', '@unit CardResponse @field(.card, Card)', true),
     description: 'Update an access card',
     requestBody: {
       content: {
@@ -319,6 +332,7 @@ export const updateCardRoute = doorlockFactory.createHandlers(
 
 export const deleteCardRoute = doorlockFactory.createHandlers(
   describeRoute({
+    ...filcExt('Doorlock', '@nodata', true),
     description: 'Delete an access card',
     responses: {
       200: { description: 'Card deleted' },

--- a/apps/chronos/src/routes/doorlock/devices.ts
+++ b/apps/chronos/src/routes/doorlock/devices.ts
@@ -9,6 +9,7 @@ import type { SuccessResponse } from '#_types/globals';
 import { db } from '#database';
 import { device } from '#database/schema/doorlock';
 import { requireAuthentication, requireAuthorization } from '#middleware/auth';
+import { filcExt } from '#utils/openapi';
 import { createSelectSchema } from '#utils/zod';
 import { doorlockFactory } from './_factory';
 
@@ -67,6 +68,11 @@ function buildConstraintError(error: unknown) {
 
 export const listDevicesRoute = doorlockFactory.createHandlers(
   describeRoute({
+    ...filcExt(
+      'Doorlock',
+      '@unit DeviceListResponse @field(.devices, List<Device>)',
+      true
+    ),
     description: 'List all doorlock devices',
     responses: {
       200: {
@@ -97,6 +103,11 @@ export const listDevicesRoute = doorlockFactory.createHandlers(
 
 export const createDeviceRoute = doorlockFactory.createHandlers(
   describeRoute({
+    ...filcExt(
+      'Doorlock',
+      '@unit DeviceResponse @field(.device, Device)',
+      true
+    ),
     description: 'Create a new doorlock device',
     requestBody: {
       content: {
@@ -151,6 +162,11 @@ export const createDeviceRoute = doorlockFactory.createHandlers(
 
 export const updateDeviceRoute = doorlockFactory.createHandlers(
   describeRoute({
+    ...filcExt(
+      'Doorlock',
+      '@unit DeviceResponse @field(.device, Device)',
+      true
+    ),
     description: 'Update an existing doorlock device',
     requestBody: {
       content: {
@@ -215,6 +231,7 @@ export const updateDeviceRoute = doorlockFactory.createHandlers(
 
 export const deleteDeviceRoute = doorlockFactory.createHandlers(
   describeRoute({
+    ...filcExt('Doorlock', '@nodata', true),
     description: 'Delete a doorlock device',
     responses: {
       200: { description: 'Device deleted' },

--- a/apps/chronos/src/routes/doorlock/logs.ts
+++ b/apps/chronos/src/routes/doorlock/logs.ts
@@ -7,6 +7,7 @@ import { db } from '#database';
 import { user } from '#database/schema/authentication';
 import { auditLog, card, device } from '#database/schema/doorlock';
 import { requireAuthentication, requireAuthorization } from '#middleware/auth';
+import { filcExt } from '#utils/openapi';
 import { createSelectSchema } from '#utils/zod';
 import { doorlockFactory } from './_factory';
 
@@ -173,6 +174,11 @@ const mapRowsToLogs = (
 
 export const listLogsRoute = doorlockFactory.createHandlers(
   describeRoute({
+    ...filcExt(
+      'Doorlock',
+      '@unit DoorlockLogListResponse @field(.logs, List<DoorlockLogEntry>)',
+      true
+    ),
     description: 'List audit log entries',
     responses: {
       200: {

--- a/apps/chronos/src/routes/doorlock/self.ts
+++ b/apps/chronos/src/routes/doorlock/self.ts
@@ -17,6 +17,7 @@ import {
   fetchCards,
 } from '#utils/doorlock/cards';
 import { syncDevicesByIds } from '#utils/doorlock/device-sync';
+import { filcExt } from '#utils/openapi';
 import { createSelectSchema } from '#utils/zod';
 import { doorlockFactory } from './_factory';
 
@@ -62,6 +63,11 @@ const activationResponseSchema = z.object({
 
 export const listSelfCardsRoute = doorlockFactory.createHandlers(
   describeRoute({
+    ...filcExt(
+      'Doorlock',
+      '@unit CardListResponse @field(.cards, List<Card>)',
+      true
+    ),
     description: 'List cards owned by the authenticated user',
     responses: {
       200: {
@@ -93,6 +99,7 @@ export const listSelfCardsRoute = doorlockFactory.createHandlers(
 
 export const updateSelfCardFrozenRoute = doorlockFactory.createHandlers(
   describeRoute({
+    ...filcExt('Doorlock', '@unit CardResponse @field(.card, Card)', true),
     description: 'Update the frozen state of a user-owned card',
     requestBody: {
       content: {
@@ -160,6 +167,11 @@ export const updateSelfCardFrozenRoute = doorlockFactory.createHandlers(
 
 export const activateVirtualCardRoute = doorlockFactory.createHandlers(
   describeRoute({
+    ...filcExt(
+      'Doorlock',
+      '@unit DoorlockActivationResponse @field(.log, AuditLog)',
+      true
+    ),
     description:
       'Activate an authorized device using a user-owned virtual card',
     requestBody: {

--- a/apps/chronos/src/routes/doorlock/stats.ts
+++ b/apps/chronos/src/routes/doorlock/stats.ts
@@ -15,6 +15,7 @@ import {
   deviceHealth,
 } from '#database/schema/doorlock';
 import { requireAuthentication, requireAuthorization } from '#middleware/auth';
+import { filcExt } from '#utils/openapi';
 import { doorlockFactory } from './_factory';
 
 const logger = getLogger(['chronos', 'doorlock', 'stats']);
@@ -86,6 +87,11 @@ const sevenDaysAgo = () => {
 
 export const doorlockStatsRoute = doorlockFactory.createHandlers(
   describeRoute({
+    ...filcExt(
+      'Doorlock',
+      '@unit DoorlockStatsResponse @field(.stats, DoorlockStats)',
+      true
+    ),
     description: 'Get aggregated doorlock statistics',
     responses: {
       200: {
@@ -189,6 +195,11 @@ export const doorlockStatsRoute = doorlockFactory.createHandlers(
 
 export const deviceStatsRoute = doorlockFactory.createHandlers(
   describeRoute({
+    ...filcExt(
+      'Doorlock',
+      '@unit DeviceStatsResponse @field(.stats, List<DeviceHealthStat>)',
+      true
+    ),
     description: 'Get device health statistics',
     responses: {
       200: {

--- a/apps/chronos/src/routes/ping/index.ts
+++ b/apps/chronos/src/routes/ping/index.ts
@@ -2,6 +2,7 @@ import { describeRoute, resolver } from 'hono-openapi';
 import z from 'zod';
 import type { SuccessResponse } from '#_types/globals';
 import { pingFactory } from '#routes/ping/_factory';
+import { filcExt } from '#utils/openapi';
 
 const pingResponseSchema = z.object({
   data: z.object({
@@ -12,6 +13,7 @@ const pingResponseSchema = z.object({
 
 export const ping = pingFactory.createHandlers(
   describeRoute({
+    ...filcExt('Ping', '@unit PingResponse'),
     description: 'Health check endpoint that returns a pong response.',
     responses: {
       200: {

--- a/apps/chronos/src/routes/ping/uptime.ts
+++ b/apps/chronos/src/routes/ping/uptime.ts
@@ -5,6 +5,7 @@ import { describeRoute, resolver } from 'hono-openapi';
 import z from 'zod';
 import type { SuccessResponse } from '#_types/globals';
 import { pingFactory } from '#routes/ping/_factory';
+import { filcExt } from '#utils/openapi';
 
 dayjs.extend(relativeTime);
 dayjs.extend(duration);
@@ -19,6 +20,7 @@ const uptimeResponseSchema = z.object({
 
 export const uptime = pingFactory.createHandlers(
   describeRoute({
+    ...filcExt('Ping', '@unit UptimeResponse'),
     description: 'Get the uptime.',
     responses: {
       200: {

--- a/apps/chronos/src/routes/timetable/cohort.ts
+++ b/apps/chronos/src/routes/timetable/cohort.ts
@@ -9,6 +9,7 @@ import type { SuccessResponse } from '#_types/globals';
 import { db } from '#database';
 import { cohort, timetable } from '#database/schema/timetable';
 import { requireAuthentication } from '#middleware/auth';
+import { filcExt } from '#utils/openapi';
 import { createSelectSchema } from '#utils/zod';
 import { timetableFactory } from './_factory';
 
@@ -21,6 +22,7 @@ const getForTimetableResponseSchema = z.object({
 
 export const getCohortsForTimetable = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('Cohort', '@listof Cohort', true),
     description: 'Get cohorts for a given timetable from the database.',
     parameters: [
       {

--- a/apps/chronos/src/routes/timetable/import.ts
+++ b/apps/chronos/src/routes/timetable/import.ts
@@ -22,7 +22,7 @@ const importResponseSchema = z.object({
 const importSchema = z.object({
   name: z.string(),
   omanXml: z.file(),
-  validFrom: z.date(),
+  validFrom: z.coerce.date(),
 });
 
 export const importRoute = timetableFactory.createHandlers(

--- a/apps/chronos/src/routes/timetable/index.ts
+++ b/apps/chronos/src/routes/timetable/index.ts
@@ -8,6 +8,7 @@ import type { SuccessResponse } from '#_types/globals';
 import { db } from '#database';
 import { timetable } from '#database/schema/timetable';
 import { requireAuthentication } from '#middleware/auth';
+import { filcExt } from '#utils/openapi';
 import { createSelectSchema } from '#utils/zod';
 import { timetableFactory } from './_factory';
 
@@ -27,6 +28,7 @@ const getLatestValidReponseSchema = z.object({
 
 export const getAllTimetables = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('Timetable', '@listof Timetable', true),
     description: 'Get all timetables from the database.',
     responses: {
       200: {
@@ -67,6 +69,7 @@ const dateToYYYYMMDD = (date: Date): string =>
 
 export const getLatestValidTimetable = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('Timetable', '@unit Timetable', true),
     description: 'Get the latest valid timetable.',
     responses: {
       200: {
@@ -112,6 +115,7 @@ export const getLatestValidTimetable = timetableFactory.createHandlers(
 
 export const getAllValidTimetables = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('Timetable', '@listof Timetable', true),
     description: 'Get all the latest valid timetables.',
     responses: {
       200: {

--- a/apps/chronos/src/routes/timetable/lesson.ts
+++ b/apps/chronos/src/routes/timetable/lesson.ts
@@ -17,6 +17,7 @@ import {
   substitutionLessonMTM,
   teacher,
 } from '#database/schema/timetable';
+import { filcExt } from '#utils/openapi';
 import { createSelectSchema } from '#utils/zod';
 import { timetableFactory } from './_factory';
 
@@ -139,8 +140,12 @@ const responseSchema = z.object({
   success: z.boolean(),
 });
 
+const enrichedLessonType =
+  '@listof EnrichedLesson @field(.classrooms, List<Classroom>) @field(.day, DayDefinition) @field(.period, Period) @field(.subject, Subject) @field(.teachers, List<TeacherSummary>)';
+
 export const getLessonsForCohort = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('Lesson', enrichedLessonType),
     description: 'Get lessons for a given cohort from the database.',
     parameters: [
       {
@@ -204,6 +209,7 @@ export const getLessonsForCohort = timetableFactory.createHandlers(
 
 export const getLessonsForTeacher = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('Lesson', enrichedLessonType),
     description: 'Get lessons for a given teacher from the database.',
     parameters: [
       {
@@ -264,6 +270,7 @@ export const getLessonsForTeacher = timetableFactory.createHandlers(
 
 export const getLessonsForRoom = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('Lesson', enrichedLessonType),
     description: 'Get lessons for a given classroom from the database.',
     parameters: [
       {
@@ -324,6 +331,10 @@ export const getLessonsForRoom = timetableFactory.createHandlers(
 
 export const getLessonForId = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt(
+      'Lesson',
+      '@unit EnrichedLesson @field(.classrooms, List<Classroom>) @field(.day, DayDefinition) @field(.period, Period) @field(.subject, Subject) @field(.teachers, List<TeacherSummary>)'
+    ),
     description: 'Get a lesson by its ID from the database.',
     parameters: [
       {

--- a/apps/chronos/src/routes/timetable/moved-lesson.ts
+++ b/apps/chronos/src/routes/timetable/moved-lesson.ts
@@ -17,6 +17,7 @@ import {
   period,
 } from '#database/schema/timetable';
 import { requireAuthentication, requireAuthorization } from '#middleware/auth';
+import { filcExt } from '#utils/openapi';
 import { createInsertSchema, createSelectSchema } from '#utils/zod';
 import { timetableFactory } from './_factory';
 
@@ -172,8 +173,12 @@ const getAllResponseSchema = z.object({
   success: z.boolean(),
 });
 
+const movedLessonWithRelationsType =
+  '@listof MovedLessonWithRelations @field(.movedLesson, MovedLesson) @field(.classroom, Classroom) @field(.dayDefinition, DayDefinition) @field(.period, Period) @field(.lessons, List<String>)';
+
 export const getAllMovedLessons = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('MovedLesson', movedLessonWithRelationsType),
     description: 'Get all moved lessons.',
     responses: {
       200: {
@@ -225,6 +230,7 @@ export const getAllMovedLessons = timetableFactory.createHandlers(
 
 export const getRelevantMovedLessons = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('MovedLesson', movedLessonWithRelationsType),
     description: 'Get relevant moved lessons for a given timetable.',
     parameters: [
       {
@@ -298,6 +304,7 @@ export const getRelevantMovedLessons = timetableFactory.createHandlers(
 
 export const getMovedLessonsForCohort = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('MovedLesson', movedLessonWithRelationsType),
     description: 'Get all moved lessons for a cohort.',
     parameters: [
       {
@@ -367,6 +374,7 @@ export const getMovedLessonsForCohort = timetableFactory.createHandlers(
 
 export const getRelevantMovedLessonsForCohort = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('MovedLesson', movedLessonWithRelationsType),
     description: 'Get all relevant moved lessons for a given cohort.',
     parameters: [
       {
@@ -456,6 +464,7 @@ const createResponseSchema = z.object({
 
 export const createMovedLesson = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('MovedLesson', '@unit MovedLesson', true),
     description: 'Create a moved lesson.',
     requestBody: {
       content: {
@@ -477,8 +486,6 @@ export const createMovedLesson = timetableFactory.createHandlers(
   }),
   requireAuthentication,
   requireAuthorization('movedLesson:create'),
-  // TODO: timetable awareness for validation
-  // zValidator('param', z.object({ timetableId: z.uuid() })),
   zValidator('json', createSchema),
   async (c) => {
     try {
@@ -549,6 +556,7 @@ const updateSchema = z.object({
 
 export const updateMovedLesson = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('MovedLesson', '@unit MovedLesson', true),
     description: 'Update a moved lesson.',
     parameters: [
       {
@@ -644,6 +652,7 @@ export const updateMovedLesson = timetableFactory.createHandlers(
 
 export const deleteMovedLesson = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('MovedLesson', '@nodata', true),
     description: 'Delete a moved lesson',
     parameters: [
       {

--- a/apps/chronos/src/routes/timetable/room.ts
+++ b/apps/chronos/src/routes/timetable/room.ts
@@ -3,16 +3,20 @@ import z from 'zod';
 import type { SuccessResponse } from '#_types/globals';
 import { db } from '#database';
 import { classroom } from '#database/schema/timetable';
+import { filcExt } from '#utils/openapi';
 import { createSelectSchema } from '#utils/zod';
 import { timetableFactory } from './_factory';
 
 const getClassroomsResponseSchema = z.object({
-  data: createSelectSchema(classroom).array(),
+  data: createSelectSchema(classroom, {
+    buildingId: z.string().nullable(),
+  }).array(),
   success: z.boolean(),
 });
 
 export const getClassrooms = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('Classroom', '@listof Classroom'),
     description: 'Get all classrooms from the database.',
     responses: {
       200: {

--- a/apps/chronos/src/routes/timetable/substitution.ts
+++ b/apps/chronos/src/routes/timetable/substitution.ts
@@ -21,6 +21,7 @@ import {
 } from '#database/schema/timetable';
 import { requireAuthentication, requireAuthorization } from '#middleware/auth';
 import { env } from '#utils/environment';
+import { filcExt } from '#utils/openapi';
 import {
   createInsertSchema,
   createSelectSchema,
@@ -64,12 +65,7 @@ const allSubstitutionsResponseSchema = z.object({
     z.object({
       lessons: z.array(enrichedSubstitutionLessonSchema),
       substitution: substitutionSchema,
-      teacher: z.object({
-        firstName: z.string().nullable(),
-        id: z.string().nullable(),
-        lastName: z.string().nullable(),
-        short: z.string().nullable(),
-      }),
+      teacher: createSelectSchema(teacher).nullable(),
     })
   ),
   success: z.boolean(),
@@ -212,8 +208,12 @@ async function enrichLessons(lessonIds: string[]) {
   });
 }
 
+const substitutionWithRelationsType =
+  '@listof SubstitutionWithRelations @field(.substitution, Substitution) @field(.teacher, Teacher) @field(.lessons, List<String>)';
+
 export const getAllSubstitutions = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('Substitution', substitutionWithRelationsType, true),
     description: 'Get all substitutions from the database.',
     responses: {
       200: {
@@ -306,6 +306,7 @@ export const getAllSubstitutions = timetableFactory.createHandlers(
 
 export const getRelevantSubstitutions = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('Substitution', substitutionWithRelationsType, true),
     description: 'Get relevant substitutions from the database.',
     responses: {
       200: {
@@ -359,6 +360,11 @@ export const getRelevantSubstitutions = timetableFactory.createHandlers(
 export const getRelevantSubstitutionsForCohort =
   timetableFactory.createHandlers(
     describeRoute({
+      ...filcExt(
+        'Substitution',
+        '@unit SubstitutionsByCohort @field(.substitutions, List<SubstitutionWithRelations>)',
+        true
+      ),
       description:
         'Get relevant substitutions for a given cohort from the database.',
       parameters: [
@@ -451,6 +457,7 @@ const createResponseSchema = z.object({
 
 export const createSubstitution = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('Substitution', '@unit Substitution', true),
     description: 'Create a new substitution',
     requestBody: {
       content: {
@@ -531,6 +538,7 @@ const updateSchema = createUpdateSchema(substitution)
 
 export const updateSubstitution = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('Substitution', '@unit Substitution', true),
     description: 'Update a substitution',
     parameters: [
       {
@@ -641,6 +649,7 @@ export const updateSubstitution = timetableFactory.createHandlers(
 
 export const deleteSubstitution = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('Substitution', '@nodata', true),
     description: 'Delete a substitution',
     parameters: [
       {

--- a/apps/chronos/src/routes/timetable/teacher.ts
+++ b/apps/chronos/src/routes/timetable/teacher.ts
@@ -3,6 +3,7 @@ import z from 'zod';
 import type { SuccessResponse } from '#_types/globals';
 import { db } from '#database';
 import { teacher } from '#database/schema/timetable';
+import { filcExt } from '#utils/openapi';
 import { createSelectSchema } from '#utils/zod';
 import { timetableFactory } from './_factory';
 
@@ -13,6 +14,7 @@ const getTeachersResponseSchema = z.object({
 
 export const getTeachers = timetableFactory.createHandlers(
   describeRoute({
+    ...filcExt('Teacher', '@listof Teacher'),
     description: 'Get all teachers from the database.',
     responses: {
       200: {

--- a/apps/chronos/src/routes/users/index.ts
+++ b/apps/chronos/src/routes/users/index.ts
@@ -10,6 +10,8 @@ import { user } from '#database/schema/authentication';
 import { requireAuthentication, requireAuthorization } from '#middleware/auth';
 import { usersFactory } from '#routes/users/_factory';
 import { getUserPermissions } from '#utils/authorization';
+import { filcExt } from '#utils/openapi';
+import { createSelectSchema } from '#utils/zod';
 
 const listUsersQuerySchema = z.object({
   limit: z.coerce.number().min(1).max(100).default(20),
@@ -26,11 +28,39 @@ const updateUserBodySchema = (
   await resolver(userUpdatePayload).toOpenAPISchema()
 ).schema;
 
+const userSchema = createSelectSchema(user).extend({
+  displayName: z.string(),
+  permissions: z.array(z.string()),
+});
+
+const listUsersResponseSchema = z.object({
+  data: z.object({
+    total: z.number(),
+    users: z.array(userSchema),
+  }),
+  success: z.boolean(),
+});
+
+const updateUserResponseSchema = z.object({
+  data: userSchema,
+  success: z.boolean(),
+});
+
 export const listUsers = usersFactory.createHandlers(
   describeRoute({
+    ...filcExt(
+      'Users',
+      '@unit UserListResponse @field(.users, List<User>) @field(.total, Int)',
+      true
+    ),
     description: 'List users',
     responses: {
       200: {
+        content: {
+          'application/json': {
+            schema: resolver(listUsersResponseSchema),
+          },
+        },
         description: 'List of users',
       },
     },
@@ -80,6 +110,7 @@ export const listUsers = usersFactory.createHandlers(
 
 export const updateUser = usersFactory.createHandlers(
   describeRoute({
+    ...filcExt('Users', '@unit User', true),
     description: 'Update user',
     requestBody: {
       content: {
@@ -88,6 +119,11 @@ export const updateUser = usersFactory.createHandlers(
     },
     responses: {
       200: {
+        content: {
+          'application/json': {
+            schema: resolver(updateUserResponseSchema),
+          },
+        },
         description: 'User updated',
       },
     },

--- a/apps/chronos/src/utils/openapi.ts
+++ b/apps/chronos/src/utils/openapi.ts
@@ -1,0 +1,8 @@
+// Spreading the result of this function into a describeRoute() object bypasses
+// TypeScript's excess property checking (only fresh object literals are checked),
+// while still embedding the x-filc_* values in the OpenAPI output at runtime.
+export const filcExt = (groupName: string, typeName: string, auth = false) => ({
+  'x-filc_group_name': groupName,
+  'x-filc_type_name': typeName,
+  ...(auth && { 'x-filc_auth': 'true' }),
+});


### PR DESCRIPTION
- Add filcExt helper utility for x-filc_* OpenAPI extension fields
- Annotate all routes with x-filc_group_name and x-filc_type_name
- Add response schemas to all timetable, cohort, doorlock, ping, and users endpoints
- Fix SubstitutionWithRelations teacher field to be nullable (createSelectSchema(teacher).nullable())
- Fix Classroom buildingId to be nullable (z.string().nullable()) to match actual DB data