### PR TITLE
Admin substitution page UI fixes

### DIFF
--- a/apps/iris/src/components/admin/substitution-dialog.tsx
+++ b/apps/iris/src/components/admin/substitution-dialog.tsx
@@ -206,6 +206,20 @@ export function SubstitutionDialog({
     }));
   }, [substituteCandidatesQuery.data, t]);
 
+  const sortedSubstituteOptions = useMemo(() => {
+    return [...substituteOptions].sort((a, b) => {
+      const aIsH1 = a.label.includes('H1');
+      const bIsH1 = b.label.includes('H1');
+      if (aIsH1 && !bIsH1) {
+        return -1;
+      }
+      if (!aIsH1 && bIsH1) {
+        return 1;
+      }
+      return a.label.localeCompare(b.label, undefined, { sensitivity: 'base' });
+    });
+  }, [substituteOptions]);
+
   const isCreate = !item;
 
   const isValid = !!formDate && formLessonIds.length > 0;
@@ -344,7 +358,7 @@ export function SubstitutionDialog({
                     label: `${t('substitution.merged')} - ${teacher.name}`,
                     value: `__merged__:${teacher.id}`,
                   })),
-                  ...substituteOptions,
+                  ...sortedSubstituteOptions,
                 ]}
                 placeholder={t('substitution.substituteTeacher')}
                 searchPlaceholder={t('search')}

--- a/apps/iris/src/components/admin/substitution-dialog.tsx
+++ b/apps/iris/src/components/admin/substitution-dialog.tsx
@@ -315,22 +315,24 @@ export function SubstitutionDialog({
                 {selectedMissingTeacher &&
                   !substituteCandidatesQuery.isLoading &&
                   availableLessons.length > 0 &&
-                  availableLessons.map((lesson) => (
-                    <label
-                      className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent"
-                      htmlFor={`sub-lesson-${lesson.id}`}
-                      key={lesson.id}
-                    >
-                      <Checkbox
-                        checked={formLessonIds.includes(lesson.id)}
-                        id={`sub-lesson-${lesson.id}`}
-                        onCheckedChange={(checked) =>
-                          toggleLesson(lesson.id, !!checked)
-                        }
-                      />
-                      <span>{formatLessonLabel(lesson)}</span>
-                    </label>
-                  ))}
+                  [...availableLessons]
+                    .sort((a, b) => (a.period?.period ?? 0) - (b.period?.period ?? 0))
+                    .map((lesson) => (
+                      <label
+                        className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent"
+                        htmlFor={`sub-lesson-${lesson.id}`}
+                        key={lesson.id}
+                      >
+                        <Checkbox
+                          checked={formLessonIds.includes(lesson.id)}
+                          id={`sub-lesson-${lesson.id}`}
+                          onCheckedChange={(checked) =>
+                            toggleLesson(lesson.id, !!checked)
+                          }
+                        />
+                        <span>{formatLessonLabel(lesson)}</span>
+                      </label>
+                    ))}
               </div>
             </div>
 

--- a/apps/iris/src/components/admin/substitution-dialog.tsx
+++ b/apps/iris/src/components/admin/substitution-dialog.tsx
@@ -316,7 +316,10 @@ export function SubstitutionDialog({
                   !substituteCandidatesQuery.isLoading &&
                   availableLessons.length > 0 &&
                   [...availableLessons]
-                    .sort((a, b) => (a.period?.period ?? 0) - (b.period?.period ?? 0))
+                    .sort(
+                      (a, b) =>
+                        (a.period?.period ?? 0) - (b.period?.period ?? 0)
+                    )
                     .map((lesson) => (
                       <label
                         className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Lessons in the substitution dialog are now sorted by period number for easier navigation.
  * Substitute teacher options are ordered to show preferred staff (H1) first, then others alphabetically (case-insensitive) for quicker selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/filcdev/filc/pull/217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->