### PR TITLE
feat(doorlock): add getOwnerLabel utility function  #221 

### DIFF
--- a/apps/iris/public/locales/en/translation.json
+++ b/apps/iris/public/locales/en/translation.json
@@ -71,6 +71,7 @@
     "cards": "Cards",
     "logs": "Logs",
     "manage-cards": "Manage Cards",
+    "unknownUser": "Unknown user",
     "selfCards": {
       "title": "My Access Cards",
       "loadError": "Failed to load your cards.",

--- a/apps/iris/public/locales/hu/translation.json
+++ b/apps/iris/public/locales/hu/translation.json
@@ -60,6 +60,7 @@
     "cards": "Kártyák",
     "logs": "Naplók",
     "manage-cards": "Kártyák kezelése",
+    "unknownUser": "Ismeretlen felhasználó",
     "selfCards": {
       "title": "Belépőkártyáim",
       "loadError": "Nem sikerült betölteni a kártyáidat.",

--- a/apps/iris/src/components/doorlock/card-dialog.tsx
+++ b/apps/iris/src/components/doorlock/card-dialog.tsx
@@ -1,6 +1,8 @@
 import { useForm, useStore } from '@tanstack/react-form';
 import { Save } from 'lucide-react';
 import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { getOwnerLabel } from '@/components/doorlock/doorlock.utils';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
@@ -27,7 +29,6 @@ import type {
   DeviceOption,
   UserOption,
 } from './doorlock.types';
-import { getOwnerLabel } from './doorlock.utils';
 
 const initialState = (card?: CardLike | null): CardFormValues => ({
   authorizedDeviceIds: card?.authorizedDevices.map((device) => device.id) ?? [],
@@ -51,6 +52,7 @@ export function CardDialog<
   users,
 }: CardDialogProps<TCard, TDevice, TUser>) {
   const isCreate = !card;
+  const { t } = useTranslation();
 
   const form = useForm({
     defaultValues: initialState(card),
@@ -139,7 +141,7 @@ export function CardDialog<
                 <FieldLabel>Owner</FieldLabel>
                 <Select
                   items={users.map((user) => ({
-                    label: getOwnerLabel(user),
+                    label: getOwnerLabel(user) || t('doorlock.unknownUser'),
                     value: user.id,
                   }))}
                   onValueChange={(value) => field.handleChange(value ?? null)}
@@ -151,7 +153,7 @@ export function CardDialog<
                   <SelectContent>
                     {users.map((user) => (
                       <SelectItem key={user.id} value={user.id}>
-                        {getOwnerLabel(user)}
+                        {getOwnerLabel(user) || t('doorlock.unknownUser')}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/apps/iris/src/components/doorlock/card-dialog.tsx
+++ b/apps/iris/src/components/doorlock/card-dialog.tsx
@@ -27,6 +27,7 @@ import type {
   DeviceOption,
   UserOption,
 } from './doorlock.types';
+import { getOwnerLabel } from './doorlock.utils';
 
 const initialState = (card?: CardLike | null): CardFormValues => ({
   authorizedDeviceIds: card?.authorizedDevices.map((device) => device.id) ?? [],
@@ -138,8 +139,7 @@ export function CardDialog<
                 <FieldLabel>Owner</FieldLabel>
                 <Select
                   items={users.map((user) => ({
-                    label:
-                      user.nickname ?? user.name ?? user.email ?? 'Unknown',
+                    label: getOwnerLabel(user),
                     value: user.id,
                   }))}
                   onValueChange={(value) => field.handleChange(value ?? null)}
@@ -151,7 +151,7 @@ export function CardDialog<
                   <SelectContent>
                     {users.map((user) => (
                       <SelectItem key={user.id} value={user.id}>
-                        {user.nickname ?? user.name ?? user.email ?? 'Unknown'}
+                        {getOwnerLabel(user)}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/apps/iris/src/components/doorlock/doorlock.utils.ts
+++ b/apps/iris/src/components/doorlock/doorlock.utils.ts
@@ -1,0 +1,21 @@
+import type { UserOption } from './doorlock.types';
+
+export function getOwnerLabel(user: UserOption) {
+  if (user.nickname && user.name && user.nickname !== user.name) {
+    return `${user.nickname} (${user.name})`;
+  }
+
+  if (user.nickname) {
+    return user.nickname;
+  }
+
+  if (user.name) {
+    return user.name;
+  }
+
+  if (user.email) {
+    return user.email;
+  }
+
+  return 'Unknown';
+}

--- a/apps/iris/src/components/doorlock/doorlock.utils.ts
+++ b/apps/iris/src/components/doorlock/doorlock.utils.ts
@@ -1,4 +1,4 @@
-import type { UserOption } from './doorlock.types';
+import type { UserOption } from '@/components/doorlock/doorlock.types';
 
 export function getOwnerLabel(user: UserOption) {
   if (user.nickname && user.name && user.nickname !== user.name) {
@@ -17,5 +17,5 @@ export function getOwnerLabel(user: UserOption) {
     return user.email;
   }
 
-  return 'Unknown';
+  return '';
 }

--- a/apps/iris/src/routes/_private/admin/doorlock/cards.tsx
+++ b/apps/iris/src/routes/_private/admin/doorlock/cards.tsx
@@ -11,6 +11,7 @@ import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { CardDialog } from '@/components/doorlock/card-dialog';
+import { getOwnerLabel } from '@/components/doorlock/doorlock.utils';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -155,12 +156,9 @@ function CardsPage() {
 
     if (term) {
       filtered = filtered.filter((card) => {
-        const ownerLabel = (
-          card.owner?.nickname ||
-          card.owner?.name ||
-          card.owner?.email ||
-          ''
-        ).toLowerCase();
+        const ownerLabel = card.owner
+          ? getOwnerLabel(card.owner).toLowerCase()
+          : '';
         return (
           card.name.toLowerCase().includes(term) ||
           ownerLabel.includes(term) ||
@@ -369,10 +367,7 @@ function CardsPage() {
               <TableRow key={card.id}>
                 <TableCell className="font-medium">{card.name}</TableCell>
                 <TableCell>
-                  {card.owner?.nickname ||
-                    card.owner?.name ||
-                    card.owner?.email ||
-                    'Unknown user'}
+                  {card.owner ? getOwnerLabel(card.owner) : 'Unknown user'}
                 </TableCell>
                 <TableCell>
                   <div className="flex flex-wrap gap-1">
@@ -481,9 +476,7 @@ function getCardSortValue(card: DoorlockCard, column: CardSortColumn) {
     case 'name':
       return card.name;
     case 'owner':
-      return (
-        card.owner?.nickname || card.owner?.name || card.owner?.email || ''
-      );
+      return card.owner ? getOwnerLabel(card.owner) : '';
     case 'status':
       if (!card.enabled) {
         return 2;

--- a/apps/iris/src/routes/_private/admin/doorlock/cards.tsx
+++ b/apps/iris/src/routes/_private/admin/doorlock/cards.tsx
@@ -9,6 +9,7 @@ import {
 import { Ban, CreditCard, Lock, Pen, Plus, Trash } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { CardDialog } from '@/components/doorlock/card-dialog';
 import { getOwnerLabel } from '@/components/doorlock/doorlock.utils';
@@ -55,6 +56,7 @@ type CardSortColumn = 'name' | 'owner' | 'status' | 'devices' | 'updated';
 function CardsPage() {
   const queryClient = useQueryClient();
   const { data: session } = authClient.useSession();
+  const { t } = useTranslation();
   const [search, setSearch] = useState('');
   const [sortColumn, setSortColumn] = useState<CardSortColumn | null>(null);
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc' | null>(
@@ -367,7 +369,9 @@ function CardsPage() {
               <TableRow key={card.id}>
                 <TableCell className="font-medium">{card.name}</TableCell>
                 <TableCell>
-                  {card.owner ? getOwnerLabel(card.owner) : 'Unknown user'}
+                  {card.owner
+                    ? getOwnerLabel(card.owner) || t('doorlock.unknownUser')
+                    : t('doorlock.unknownUser')}
                 </TableCell>
                 <TableCell>
                   <div className="flex flex-wrap gap-1">


### PR DESCRIPTION
This pull request refactors how user labels are generated and displayed in the doorlock card management UI. The main change is the introduction of a new utility function, `getOwnerLabel`, which centralizes and standardizes the logic for formatting user display names across multiple components and features. This ensures consistency in how user information is shown, searched, and sorted.

**User label formatting improvements:**

* Added a new utility function `getOwnerLabel` in `doorlock.utils.ts` to generate consistent user labels based on available user fields (`nickname`, `name`, `email`).
* Updated all locations in `card-dialog.tsx` where user labels are displayed (in form selects) to use `getOwnerLabel` instead of inline logic. [[1]](diffhunk://#diff-c61bbc875fa15dc7743d50d938e9ece4b0b2bc299ac99cb928a2bd9f1438f5e1R30) [[2]](diffhunk://#diff-c61bbc875fa15dc7743d50d938e9ece4b0b2bc299ac99cb928a2bd9f1438f5e1L141-R142) [[3]](diffhunk://#diff-c61bbc875fa15dc7743d50d938e9ece4b0b2bc299ac99cb928a2bd9f1438f5e1L154-R154)

**Consistency in user display across the UI:**

* Updated the cards admin page to use `getOwnerLabel` for filtering, displaying, and sorting card owners, ensuring consistent and more readable owner labels throughout the interface. [[1]](diffhunk://#diff-93fb4f2947d5c0e728a83ae151af5bb9094fd411cf6a1c3125c54fbca92d9d8cR14) [[2]](diffhunk://#diff-93fb4f2947d5c0e728a83ae151af5bb9094fd411cf6a1c3125c54fbca92d9d8cL158-R161) [[3]](diffhunk://#diff-93fb4f2947d5c0e728a83ae151af5bb9094fd411cf6a1c3125c54fbca92d9d8cL372-R370) [[4]](diffhunk://#diff-93fb4f2947d5c0e728a83ae151af5bb9094fd411cf6a1c3125c54fbca92d9d8cL484-R479)

Closes #221 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified owner name formatting across the doorlock UI for consistent display, search, and sorting.

* **New Features**
  * Added a localized "Unknown user" label (English and Hungarian) shown when owner information is missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/filcdev/filc/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->