### PR TITLE
fix: badge display, period num display

### DIFF
--- a/apps/iris/public/locales/en/translation.json
+++ b/apps/iris/public/locales/en/translation.json
@@ -230,7 +230,8 @@
     "availableForClass": "Substitutions are available for {{className}}",
     "yourClass": "your class",
     "cardTitle": "Substitution on {{date}}",
-    "notAvailable": "N/A"
+    "notAvailable": "N/A",
+    "period": "Period"
   },
   "movedLesson": {
     "title": "Moved Lessons",

--- a/apps/iris/public/locales/hu/translation.json
+++ b/apps/iris/public/locales/hu/translation.json
@@ -230,7 +230,8 @@
     "availableForClass": "Helyettesítések elérhetők ehhez: {{className}}",
     "yourClass": "a te osztályod",
     "cardTitle": "Helyettesítés ezen a napon: {{date}}",
-    "notAvailable": "N/A"
+    "notAvailable": "N/A",
+    "period": "Óra"
   },
   "movedLesson": {
     "title": "Áthelyezett órák",

--- a/apps/iris/src/components/subs.tsx
+++ b/apps/iris/src/components/subs.tsx
@@ -54,7 +54,7 @@ function LessonRow({
         {lesson.cohorts && lesson.cohorts.length > 0 ? (
           <div className="flex flex-wrap gap-1">
             {lesson.cohorts.map((cohort) => (
-              <Badge className="text-xs" key={cohort} variant="secondary">
+              <Badge className="text-xs" key={cohort} variant="outline">
                 {cohort}
               </Badge>
             ))}
@@ -68,6 +68,8 @@ function LessonRow({
           <span className="font-medium">
             {lesson.period.startTime.slice(0, 5)} –{' '}
             {lesson.period.endTime.slice(0, 5)}
+            {', '}
+            {lesson.period.period}. {t('substitution.period')}
           </span>
         ) : (
           <span className="text-muted-foreground">{notAvailable}</span>

--- a/apps/iris/src/routes/_private/admin/timetable/substitutions.tsx
+++ b/apps/iris/src/routes/_private/admin/timetable/substitutions.tsx
@@ -415,7 +415,7 @@ function SubstitutionsPage() {
                   <TableCell className="font-medium">
                     {formatLocalizedDate(sub.substitution.date, i18n.language)}
                   </TableCell>
-                  <TableCell>
+                  <TableCell className="truncate">
                     {sub.teacher ? (
                       `${sub.teacher.firstName} ${sub.teacher.lastName}`
                     ) : (
@@ -425,24 +425,35 @@ function SubstitutionsPage() {
                     )}
                   </TableCell>
                   <TableCell>
-                    {sub.lessons.length > 0
-                      ? sub.lessons
-                          .filter((l) => l !== null && l !== undefined)
-                          .map(
-                            (l) =>
-                              `${l.subject?.short ?? '?'} P${l.period?.period ?? '?'}`
-                          )
-                          .join(', ')
-                      : t('substitution.noLessons')}
+                    <div className="jutify-center grid grid-cols-1 items-center gap-2 xl:grid-cols-2 2xl:grid-cols-3">
+                      {sub.lessons.length > 0
+                        ? sub.lessons
+                            .filter((l) => l !== null && l !== undefined)
+                            .map((l) => (
+                              <Badge key={l.id} variant="secondary">
+                                {l.subject?.short ?? '?'}
+                                {', '}
+                                {t('substitution.period')}{' '}
+                                {l.period?.period ?? '?'}
+                              </Badge>
+                            ))
+                        : t('substitution.noLessons')}
+                    </div>
                   </TableCell>
                   <TableCell>
-                    {Array.from(
-                      new Set(
-                        sub.lessons
-                          .filter((l) => l !== null && l !== undefined)
-                          .flatMap((l) => l.cohorts)
-                      )
-                    ).join(', ') || '-'}
+                    <div className="jutify-center grid grid-cols-1 items-center gap-2 xl:grid-cols-2 2xl:grid-cols-3">
+                      {Array.from(
+                        new Set(
+                          sub.lessons
+                            .filter((l) => l !== null && l !== undefined)
+                            .map((l) => (
+                              <Badge key={l.id} variant="secondary">
+                                {l.cohorts}
+                              </Badge>
+                            ))
+                        )
+                      )}
+                    </div>
                   </TableCell>
                   {hasWritePermission && (
                     <TableCell>

--- a/apps/iris/src/routes/_private/admin/timetable/substitutions.tsx
+++ b/apps/iris/src/routes/_private/admin/timetable/substitutions.tsx
@@ -425,7 +425,7 @@ function SubstitutionsPage() {
                     )}
                   </TableCell>
                   <TableCell>
-                    <div className="jutify-center grid grid-cols-1 items-center gap-2 xl:grid-cols-2 2xl:grid-cols-3">
+                    <div className="grid grid-cols-1 items-center justify-center gap-2 xl:grid-cols-2 2xl:grid-cols-3">
                       {sub.lessons.length > 0
                         ? sub.lessons
                             .filter((l) => l !== null && l !== undefined)
@@ -441,18 +441,18 @@ function SubstitutionsPage() {
                     </div>
                   </TableCell>
                   <TableCell>
-                    <div className="jutify-center grid grid-cols-1 items-center gap-2 xl:grid-cols-2 2xl:grid-cols-3">
+                    <div className="grid grid-cols-1 items-center justify-center gap-2 xl:grid-cols-2 2xl:grid-cols-3">
                       {Array.from(
                         new Set(
                           sub.lessons
                             .filter((l) => l !== null && l !== undefined)
-                            .map((l) => (
-                              <Badge key={l.id} variant="secondary">
-                                {l.cohorts}
-                              </Badge>
-                            ))
+                            .flatMap((l) => l.cohorts)
                         )
-                      )}
+                      ).map((cohort) => (
+                        <Badge key={cohort} variant="secondary">
+                          {cohort}
+                        </Badge>
+                      ))}
                     </div>
                   </TableCell>
                   {hasWritePermission && (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized "period" label to substitution/lesson time displays.

* **Style**
  * Updated substitution badge styling for improved visual consistency.
  * Redesigned affected lessons and cohorts into grid-based badge layouts for clearer organization.
  * Applied truncation to teacher names and show empty grid when no cohorts instead of a fallback dash.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/filcdev/filc/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->