### PR TITLE
fix(navbar): conditionally render NotificationBell based on session and disable Notification Query when no user logged in

### DIFF
--- a/apps/iris/src/components/navbar.tsx
+++ b/apps/iris/src/components/navbar.tsx
@@ -74,7 +74,7 @@ export function Navbar({
           )}
 
           <div className="ml-auto flex items-center gap-3">
-            <NotificationBell />
+            {data && <NotificationBell />}
 
             <LanguageSelector />
 

--- a/apps/iris/src/components/notification-bell.tsx
+++ b/apps/iris/src/components/notification-bell.tsx
@@ -64,7 +64,7 @@ export function NotificationBell() {
       }
       return (res.data ?? []) as NotificationItem[];
     },
-    queryKey: ['notifications', 'recent'] as const,
+    queryKey: queryKeys.notifications.recent(),
     refetchInterval: 30_000,
   });
 

--- a/apps/iris/src/components/notification-bell.tsx
+++ b/apps/iris/src/components/notification-bell.tsx
@@ -36,10 +36,10 @@ export function NotificationBell() {
   const queryClient = useQueryClient();
   const [historyOpen, setHistoryOpen] = useState(false);
   const { data: session } = authClient.useSession();
-  const user = session?.user;
+  const userId = session?.session.userId;
 
   const { data: unreadData } = useQuery({
-    enabled: !!user,
+    enabled: !!userId,
     queryFn: async () => {
       const res = await parseResponse(api.notifications['unread-count'].$get());
       if (!res.success) {
@@ -47,12 +47,12 @@ export function NotificationBell() {
       }
       return res.data as UnreadCountData;
     },
-    queryKey: queryKeys.notifications.unreadCount(),
+    queryKey: queryKeys.notifications.unreadCount(userId ?? ''),
     refetchInterval: 30_000,
   });
 
   const { data: recentData } = useQuery({
-    enabled: !!user,
+    enabled: !!userId,
     queryFn: async () => {
       const res = await parseResponse(
         api.notifications.index.$get({
@@ -64,7 +64,7 @@ export function NotificationBell() {
       }
       return (res.data ?? []) as NotificationItem[];
     },
-    queryKey: queryKeys.notifications.recent(),
+    queryKey: queryKeys.notifications.recent(userId ?? ''),
     refetchInterval: 30_000,
   });
 

--- a/apps/iris/src/components/notification-bell.tsx
+++ b/apps/iris/src/components/notification-bell.tsx
@@ -15,6 +15,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { authClient } from '@/utils/authentication';
 import { api } from '@/utils/hc';
 import { queryKeys } from '@/utils/query-keys';
 
@@ -34,8 +35,11 @@ export function NotificationBell() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const [historyOpen, setHistoryOpen] = useState(false);
+  const { data: session } = authClient.useSession();
+  const user = session?.user;
 
   const { data: unreadData } = useQuery({
+    enabled: !!user,
     queryFn: async () => {
       const res = await parseResponse(api.notifications['unread-count'].$get());
       if (!res.success) {
@@ -48,6 +52,7 @@ export function NotificationBell() {
   });
 
   const { data: recentData } = useQuery({
+    enabled: !!user,
     queryFn: async () => {
       const res = await parseResponse(
         api.notifications.index.$get({

--- a/apps/iris/src/utils/query-keys.ts
+++ b/apps/iris/src/utils/query-keys.ts
@@ -52,9 +52,10 @@ export const queryKeys = {
     ) =>
       ['notifications', 'list', type, unread, page, dateFrom, dateTo] as const,
     preferences: () => ['notifications', 'preferences'] as const,
-    recent: () => ['notifications', 'recent'] as const,
+    recent: (userId: string) => ['notifications', 'recent', userId] as const,
     settings: () => ['notifications', 'settings'] as const,
-    unreadCount: () => ['notifications', 'unread-count'] as const,
+    unreadCount: (userId: string) =>
+      ['notifications', 'unread-count', userId] as const,
   },
   permissions: () => ['permissions'] as const,
   roles: () => ['roles'] as const,

--- a/apps/iris/src/utils/query-keys.ts
+++ b/apps/iris/src/utils/query-keys.ts
@@ -52,6 +52,7 @@ export const queryKeys = {
     ) =>
       ['notifications', 'list', type, unread, page, dateFrom, dateTo] as const,
     preferences: () => ['notifications', 'preferences'] as const,
+    recent: () => ['notifications', 'recent'] as const,
     settings: () => ['notifications', 'settings'] as const,
     unreadCount: () => ['notifications', 'unread-count'] as const,
   },


### PR DESCRIPTION
This pull request improves the behavior of the `NotificationBell` component by ensuring it only loads notification data for authenticated users. It also updates the `Navbar` to only render the notification bell when user data is available. These changes help prevent unnecessary API calls and UI rendering for unauthenticated users.

**Authentication-aware notification loading:**

* [`apps/iris/src/components/notification-bell.tsx`](diffhunk://#diff-b6a7b5223f25deb255a478dfd8004469ba77288dbb716af95e867ebb1f3652a5R18): Added authentication check using `authClient.useSession()` and updated notification queries (`useQuery`) to only run when a user is present. [[1]](diffhunk://#diff-b6a7b5223f25deb255a478dfd8004469ba77288dbb716af95e867ebb1f3652a5R18) [[2]](diffhunk://#diff-b6a7b5223f25deb255a478dfd8004469ba77288dbb716af95e867ebb1f3652a5R38-R42) [[3]](diffhunk://#diff-b6a7b5223f25deb255a478dfd8004469ba77288dbb716af95e867ebb1f3652a5R55)

**Conditional rendering in navigation:**

* [`apps/iris/src/components/navbar.tsx`](diffhunk://#diff-bf3929f20a3957bfcbf978f802af627c52cd2db74efd8f7ded869761f879cceaL77-R77): Modified to render `NotificationBell` only when user data (`data`) is available.

Closes #198 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notification bell now only appears for signed-in users.
  * Notifications stop making background requests when you're not signed in.

* **Chores**
  * Improved per-user caching for recent notifications to make counts and recent items more reliable and efficient.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/filcdev/filc/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->