### PR TITLE
fix(api): update production server URL in OpenAPI docs

### DIFF
--- a/apps/chronos/src/index.ts
+++ b/apps/chronos/src/index.ts
@@ -137,7 +137,7 @@ api.get(
       servers: [
         env.mode === 'development'
           ? { description: 'Local Server', url: 'http://localhost:3000/api' }
-          : { description: 'chronos', url: 'https://filc.space/api' },
+          : { description: 'chronos', url: 'https://filc.petrik.hu/api' },
       ],
     },
   })


### PR DESCRIPTION
This pull request makes a small but important update to the server configuration for the API documentation. The production server URL has been changed to reflect the new domain.

- Updated the production server URL in the OpenAPI configuration from `https://filc.space/api` to `https://filc.petrik.hu/api` in `apps/chronos/src/index.ts`.

Closes #233  
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API server endpoint configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->