### PR TITLE
refactor(lesson-card): restructure room display logic

### DIFF
--- a/apps/iris/src/components/timetable/lesson-card.tsx
+++ b/apps/iris/src/components/timetable/lesson-card.tsx
@@ -40,9 +40,11 @@ export function LessonCard({ lesson }: LessonCardProps) {
             )}
           >
             <div className="font-semibold text-sm leading-none">{short}</div>
-            <div className="mt-0.5 w-full truncate text-center text-muted-foreground text-xs">
-              {teacher}
-            </div>
+            {teacher && (
+              <div className="mt-0.5 w-full truncate text-center text-muted-foreground text-xs">
+                {teacher}
+              </div>
+            )}
             {room && (
               <div className="w-full truncate text-center text-muted-foreground text-xs">
                 {room}

--- a/apps/iris/src/components/timetable/lesson-card.tsx
+++ b/apps/iris/src/components/timetable/lesson-card.tsx
@@ -41,8 +41,13 @@ export function LessonCard({ lesson }: LessonCardProps) {
           >
             <div className="font-semibold text-sm leading-none">{short}</div>
             <div className="mt-0.5 w-full truncate text-center text-muted-foreground text-xs">
-              {teacher} {room && <>| {room}</>}
+              {teacher}
             </div>
+            {room && (
+              <div className="w-full truncate text-center text-muted-foreground text-xs">
+                {room}
+              </div>
+            )}
           </div>
         }
       />
@@ -66,14 +71,6 @@ export function LessonCard({ lesson }: LessonCardProps) {
           </div>
 
           <div className="space-y-2 text-xs">
-            {room && (
-              <div className="flex items-center gap-1.5">
-                <span className="font-medium text-accent-foreground">
-                  <MapPinIcon />
-                </span>
-                <span className="font-bold text-foreground">{room}</span>
-              </div>
-            )}
             {teacher && (
               <div className="flex items-center gap-1.5">
                 <span className="font-medium text-accent-foreground">
@@ -82,6 +79,14 @@ export function LessonCard({ lesson }: LessonCardProps) {
                 <span className="font-bold text-foreground">
                   {lesson.teachers.map((t) => t.name).join(', ')}
                 </span>
+              </div>
+            )}
+            {room && (
+              <div className="flex items-center gap-1.5">
+                <span className="font-medium text-accent-foreground">
+                  <MapPinIcon />
+                </span>
+                <span className="font-bold text-foreground">{room}</span>
               </div>
             )}
           </div>


### PR DESCRIPTION
This pull request updates the layout of the `LessonCard` component to improve the display of teacher and room information, making it clearer and more visually consistent. The main changes involve separating the teacher and room details into distinct lines and adjusting their placement within the card.

**UI layout improvements:**

* Separated the display of the teacher and room in the card header, so the teacher is shown on one line and the room (if present) is shown on a new line below, each with appropriate styling.
* Moved the room information (with the `MapPinIcon`) to appear after the teacher in the details section, ensuring both are displayed in their own rows for clarity.
* Removed the previous conditional rendering of the room in the details section to avoid duplicate or misplaced room information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized lesson preview layout to display teacher and room information separately instead of combining them on a single line for improved readability.
  * Reordered lesson details to show teacher information before room information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->