### PR TITLE
feat(timetable): add cleanup for orphaned cohorts

### DIFF
--- a/apps/chronos/src/routes/timetable/_router.ts
+++ b/apps/chronos/src/routes/timetable/_router.ts
@@ -2,6 +2,7 @@ import { timetableFactory } from '#routes/timetable/_factory';
 import { getCohortsForTimetable } from '#routes/timetable/cohort';
 import { importRoute } from '#routes/timetable/import';
 import {
+  cleanupOrphanedCohortsHandler,
   deleteTimetable,
   getAllTimetables,
   getAllValidTimetables,
@@ -47,6 +48,10 @@ export const timetableRouter = timetableFactory
   .patch('/timetables/:id', ...updateTimetable)
   .get('/timetables/:id/preview-delete', ...previewDeleteTimetable)
   .delete('/timetables/:id', ...deleteTimetable)
+  .post(
+    '/timetables/cleanup-orphaned-cohorts',
+    ...cleanupOrphanedCohortsHandler
+  )
   .post('/import', ...importRoute)
   // Substitution routes
   .get('/substitutions', ...getAllSubstitutions)

--- a/apps/chronos/src/routes/timetable/index.ts
+++ b/apps/chronos/src/routes/timetable/index.ts
@@ -22,6 +22,7 @@ import { requireAuthentication, requireAuthorization } from '#middleware/auth';
 import { dispatchImmediateNotification } from '#utils/notifications/engine';
 import { filcExt } from '#utils/openapi';
 import { getActiveTimetableId } from '#utils/timetable/active';
+import { cleanupOrphanedCohorts } from '#utils/timetable/cleanup';
 import { dateToYYYYMMDD } from '#utils/timetable/date';
 import { createSelectSchema } from '#utils/zod';
 import { timetableFactory } from './_factory';
@@ -247,7 +248,7 @@ export const deleteTimetable = timetableFactory.createHandlers(
   describeRoute({
     ...filcExt('Timetable', '@unit Timetable', true),
     description:
-      'Delete a timetable and all its related data. Cohorts survive.',
+      'Delete a timetable and all its related data, including orphaned cohorts.',
     responses: {
       200: {
         content: {
@@ -330,6 +331,9 @@ export const deleteTimetable = timetableFactory.createHandlers(
             .where(inArray(user.id, userIds));
           notifiedUserIds.push(...userIds);
         }
+
+        // Delete orphaned cohorts that are no longer linked to any timetable
+        await tx.delete(cohort).where(inArray(cohort.id, orphanedCohortIds));
       }
 
       await tx.delete(timetable).where(eq(timetable.id, id));
@@ -374,7 +378,8 @@ const previewDeleteResponseSchema = z.object({
 export const previewDeleteTimetable = timetableFactory.createHandlers(
   describeRoute({
     ...filcExt('Timetable', '@unit Timetable', true),
-    description: 'Preview the impact of deleting a timetable.',
+    description:
+      'Preview the impact of deleting a timetable. Orphaned cohorts will be deleted along with the timetable.',
     responses: {
       200: {
         content: {
@@ -511,5 +516,49 @@ export const previewDeleteTimetable = timetableFactory.createHandlers(
       },
       success: true,
     });
+  }
+);
+
+const cleanupOrphanedCohortsResponseSchema = z.object({
+  data: z.object({
+    affectedUserCount: z.number().int(),
+    deletedCohortIds: z.array(z.string()),
+  }),
+  success: z.literal(true),
+});
+
+export const cleanupOrphanedCohortsHandler = timetableFactory.createHandlers(
+  describeRoute({
+    ...filcExt('Timetable', '@unit Timetable', true),
+    description:
+      'Delete all cohorts that are no longer linked to any timetable (orphaned). Users referencing those cohorts will have their cohortId nullified.',
+    responses: {
+      200: {
+        content: {
+          'application/json': {
+            schema: resolver(cleanupOrphanedCohortsResponseSchema),
+          },
+        },
+        description: 'Cleanup summary',
+      },
+    },
+    tags: ['Timetable'],
+  }),
+  requireAuthentication,
+  requireAuthorization('import:timetable'),
+  async (c) => {
+    try {
+      const summary = await cleanupOrphanedCohorts();
+
+      return c.json<SuccessResponse<typeof summary>>({
+        data: summary,
+        success: true,
+      });
+    } catch (error) {
+      logger.error('Failed to cleanup orphaned cohorts: ', { error });
+      throw new HTTPException(StatusCodes.INTERNAL_SERVER_ERROR, {
+        message: 'Failed to cleanup orphaned cohorts',
+      });
+    }
   }
 );

--- a/apps/chronos/src/routes/timetable/index.ts
+++ b/apps/chronos/src/routes/timetable/index.ts
@@ -518,10 +518,6 @@ export const previewDeleteTimetable = timetableFactory.createHandlers(
 );
 
 const cleanupOrphanedCohortsResponseSchema = z.object({
-  data: z.object({
-    affectedUserCount: z.number().int(),
-    deletedCohortIds: z.array(z.string()),
-  }),
   success: z.literal(true),
 });
 
@@ -546,12 +542,9 @@ export const cleanupOrphanedCohortsHandler = timetableFactory.createHandlers(
   requireAuthorization('import:timetable'),
   async (c) => {
     try {
-      const summary = await cleanupOrphanedCohorts();
+      await cleanupOrphanedCohorts();
 
-      return c.json<SuccessResponse<typeof summary>>({
-        data: summary,
-        success: true,
-      });
+      return c.json({ success: true as const });
     } catch (error) {
       logger.error('Failed to cleanup orphaned cohorts: ', { error });
       throw new HTTPException(StatusCodes.INTERNAL_SERVER_ERROR, {

--- a/apps/chronos/src/routes/timetable/index.ts
+++ b/apps/chronos/src/routes/timetable/index.ts
@@ -319,17 +319,15 @@ export const deleteTimetable = timetableFactory.createHandlers(
         .filter((cohortId) => !survivingSet.has(cohortId));
 
       if (orphanedCohortIds.length > 0) {
-        const affectedUsers = await tx
-          .select({ id: user.id })
-          .from(user)
-          .where(inArray(user.cohortId, orphanedCohortIds));
-        if (affectedUsers.length > 0) {
-          const userIds = affectedUsers.map((u) => u.id);
-          await tx
-            .update(user)
-            .set({ cohortId: null })
-            .where(inArray(user.id, userIds));
-          notifiedUserIds.push(...userIds);
+        // Nullify cohortId on users referencing orphaned cohorts in a single
+        // conditional update to avoid a race between select and update.
+        const updatedUsers = await tx
+          .update(user)
+          .set({ cohortId: null })
+          .where(inArray(user.cohortId, orphanedCohortIds))
+          .returning({ id: user.id });
+        if (updatedUsers.length > 0) {
+          notifiedUserIds.push(...updatedUsers.map((u) => u.id));
         }
 
         // Delete orphaned cohorts that are no longer linked to any timetable

--- a/apps/chronos/src/routes/timetable/index.ts
+++ b/apps/chronos/src/routes/timetable/index.ts
@@ -518,6 +518,10 @@ export const previewDeleteTimetable = timetableFactory.createHandlers(
 );
 
 const cleanupOrphanedCohortsResponseSchema = z.object({
+  data: z.object({
+    affectedUserCount: z.number(),
+    deletedCohortIds: z.array(z.string()),
+  }),
   success: z.literal(true),
 });
 
@@ -542,9 +546,12 @@ export const cleanupOrphanedCohortsHandler = timetableFactory.createHandlers(
   requireAuthorization('import:timetable'),
   async (c) => {
     try {
-      await cleanupOrphanedCohorts();
+      const result = await cleanupOrphanedCohorts();
 
-      return c.json({ success: true as const });
+      return c.json({
+        data: result,
+        success: true as const,
+      });
     } catch (error) {
       logger.error('Failed to cleanup orphaned cohorts: ', { error });
       throw new HTTPException(StatusCodes.INTERNAL_SERVER_ERROR, {

--- a/apps/chronos/src/utils/cron.ts
+++ b/apps/chronos/src/utils/cron.ts
@@ -2,6 +2,7 @@ import { getLogger } from '@logtape/logtape';
 import Baker from 'cronbake';
 import { cleanUpOldDeviceAuditLogs } from '#utils/doorlock/cards';
 import { cleanUpOldNotifications } from '#utils/notifications/cleanup';
+import { cleanupOrphanedCohorts } from '#utils/timetable/cleanup';
 
 const logger = getLogger(['chronos', 'cron']);
 
@@ -24,6 +25,12 @@ export const setupCronJobs = () => {
     callback: cleanUpOldNotifications,
     cron: '@daily',
     name: 'clean-up-old-notifications',
+  });
+
+  baker.add({
+    callback: cleanupOrphanedCohorts,
+    cron: '@daily',
+    name: 'clean-up-orphaned-cohorts',
   });
 
   const jobs = baker.getJobNames();

--- a/apps/chronos/src/utils/cron.ts
+++ b/apps/chronos/src/utils/cron.ts
@@ -28,7 +28,9 @@ export const setupCronJobs = () => {
   });
 
   baker.add({
-    callback: cleanupOrphanedCohorts,
+    callback: async () => {
+      await cleanupOrphanedCohorts();
+    },
     cron: '@daily',
     name: 'clean-up-orphaned-cohorts',
   });

--- a/apps/chronos/src/utils/timetable/cleanup.ts
+++ b/apps/chronos/src/utils/timetable/cleanup.ts
@@ -6,13 +6,6 @@ import { cohort, cohortTimetableMtm } from '#database/schema/timetable';
 
 const logger = getLogger(['chronos', 'timetable', 'cleanup']);
 
-export type OrphanCleanupSummary = {
-  /** IDs of the deleted cohort rows. */
-  deletedCohortIds: string[];
-  /** Number of users whose cohortId was nullified. */
-  affectedUserCount: number;
-};
-
 /**
  * Find and delete cohorts that are not linked to any timetable via the
  * `cohort_timetable_mtm` table.  For each orphan, any user referencing that
@@ -21,9 +14,8 @@ export type OrphanCleanupSummary = {
  * The destructive part of the operation (user nullification + cohort deletion)
  * runs inside a single database transaction.
  */
-export async function cleanupOrphanedCohorts(): Promise<OrphanCleanupSummary> {
+export async function cleanupOrphanedCohorts(): Promise<void> {
   let affectedUserCount = 0;
-  let deletedCohortIds: string[] = [];
 
   await db.transaction(async (tx) => {
     // Find all cohort IDs that are referenced in the MTM table
@@ -68,9 +60,5 @@ export async function cleanupOrphanedCohorts(): Promise<OrphanCleanupSummary> {
     logger.info('Deleted orphaned cohorts', {
       count: orphanedCohortIds.length,
     });
-
-    deletedCohortIds = orphanedCohortIds;
   });
-
-  return { affectedUserCount, deletedCohortIds };
 }

--- a/apps/chronos/src/utils/timetable/cleanup.ts
+++ b/apps/chronos/src/utils/timetable/cleanup.ts
@@ -6,27 +6,39 @@ import { cohort, cohortTimetableMtm } from '#database/schema/timetable';
 
 const logger = getLogger(['chronos', 'timetable', 'cleanup']);
 
+export type CleanupOrphanedCohortsResult = {
+  affectedUserCount: number;
+  deletedCohortIds: string[];
+};
+
 /**
  * Find and delete cohorts that are not linked to any timetable via the
  * `cohort_timetable_mtm` table.  For each orphan, any user referencing that
  * cohort has their `cohortId` set to NULL before the cohort row is removed.
  *
  * The destructive part of the operation (user nullification + cohort deletion)
- * runs inside a single database transaction.
+ * runs inside a single database transaction.  Cohort rows are locked with
+ * `FOR UPDATE` before computing the orphan set to prevent a race where a
+ * concurrent insert into `cohort_timetable_mtm` would be cascade-deleted.
  */
-export async function cleanupOrphanedCohorts(): Promise<void> {
+export async function cleanupOrphanedCohorts(): Promise<CleanupOrphanedCohortsResult> {
   let affectedUserCount = 0;
+  let deletedCohortIds: string[] = [];
 
   await db.transaction(async (tx) => {
+    // Lock all cohort rows to prevent concurrent MTM inserts that would
+    // create a race between computing orphans and deleting them.
+    const allCohortRows = await tx
+      .select({ id: cohort.id })
+      .from(cohort)
+      .for('update');
+
     // Find all cohort IDs that are referenced in the MTM table
     const linkedRows = await tx
       .selectDistinct({ cohortId: cohortTimetableMtm.cohortId })
       .from(cohortTimetableMtm);
 
     const linkedSet = new Set(linkedRows.map((r) => r.cohortId));
-
-    // Find all cohort IDs
-    const allCohortRows = await tx.select({ id: cohort.id }).from(cohort);
 
     // Cohorts whose ID does not appear in the MTM table are orphaned
     const orphanedCohortIds = allCohortRows
@@ -57,8 +69,11 @@ export async function cleanupOrphanedCohorts(): Promise<void> {
 
     // Delete the orphaned cohort rows
     await tx.delete(cohort).where(inArray(cohort.id, orphanedCohortIds));
+    deletedCohortIds = orphanedCohortIds;
     logger.info('Deleted orphaned cohorts', {
       count: orphanedCohortIds.length,
     });
   });
+
+  return { affectedUserCount, deletedCohortIds };
 }

--- a/apps/chronos/src/utils/timetable/cleanup.ts
+++ b/apps/chronos/src/utils/timetable/cleanup.ts
@@ -22,45 +22,45 @@ export type OrphanCleanupSummary = {
  * runs inside a single database transaction.
  */
 export async function cleanupOrphanedCohorts(): Promise<OrphanCleanupSummary> {
-  // Find all cohort IDs that are referenced in the MTM table
-  const linkedRows = await db
-    .selectDistinct({ cohortId: cohortTimetableMtm.cohortId })
-    .from(cohortTimetableMtm);
-
-  const linkedSet = new Set(linkedRows.map((r) => r.cohortId));
-
-  // Find all cohort IDs
-  const allCohortRows = await db.select({ id: cohort.id }).from(cohort);
-
-  // Cohorts whose ID does not appear in the MTM table are orphaned
-  const orphanedCohortIds = allCohortRows
-    .map((r) => r.id)
-    .filter((id) => !linkedSet.has(id));
-
-  if (orphanedCohortIds.length === 0) {
-    logger.info('No orphaned cohorts found.');
-    return { affectedUserCount: 0, deletedCohortIds: [] };
-  }
-
-  logger.info('Found orphaned cohorts', { count: orphanedCohortIds.length });
-
   let affectedUserCount = 0;
+  let deletedCohortIds: string[] = [];
 
   await db.transaction(async (tx) => {
-    // Nullify cohortId on users referencing orphaned cohorts
-    const affectedUsers = await tx
-      .select({ id: user.id })
-      .from(user)
-      .where(inArray(user.cohortId, orphanedCohortIds));
+    // Find all cohort IDs that are referenced in the MTM table
+    const linkedRows = await tx
+      .selectDistinct({ cohortId: cohortTimetableMtm.cohortId })
+      .from(cohortTimetableMtm);
 
-    if (affectedUsers.length > 0) {
-      const userIds = affectedUsers.map((u) => u.id);
-      await tx
-        .update(user)
-        .set({ cohortId: null })
-        .where(inArray(user.id, userIds));
-      affectedUserCount = userIds.length;
-      logger.info('Nullified cohortId for users', { count: userIds.length });
+    const linkedSet = new Set(linkedRows.map((r) => r.cohortId));
+
+    // Find all cohort IDs
+    const allCohortRows = await tx.select({ id: cohort.id }).from(cohort);
+
+    // Cohorts whose ID does not appear in the MTM table are orphaned
+    const orphanedCohortIds = allCohortRows
+      .map((r) => r.id)
+      .filter((id) => !linkedSet.has(id));
+
+    if (orphanedCohortIds.length === 0) {
+      logger.info('No orphaned cohorts found.');
+      return;
+    }
+
+    logger.info('Found orphaned cohorts', { count: orphanedCohortIds.length });
+
+    // Nullify cohortId on users referencing orphaned cohorts in a single
+    // conditional update to avoid a race between select and update.
+    const updatedUsers = await tx
+      .update(user)
+      .set({ cohortId: null })
+      .where(inArray(user.cohortId, orphanedCohortIds))
+      .returning({ id: user.id });
+
+    affectedUserCount = updatedUsers.length;
+    if (affectedUserCount > 0) {
+      logger.info('Nullified cohortId for users', {
+        count: affectedUserCount,
+      });
     }
 
     // Delete the orphaned cohort rows
@@ -68,7 +68,9 @@ export async function cleanupOrphanedCohorts(): Promise<OrphanCleanupSummary> {
     logger.info('Deleted orphaned cohorts', {
       count: orphanedCohortIds.length,
     });
+
+    deletedCohortIds = orphanedCohortIds;
   });
 
-  return { affectedUserCount, deletedCohortIds: orphanedCohortIds };
+  return { affectedUserCount, deletedCohortIds };
 }

--- a/apps/chronos/src/utils/timetable/cleanup.ts
+++ b/apps/chronos/src/utils/timetable/cleanup.ts
@@ -1,0 +1,74 @@
+import { getLogger } from '@logtape/logtape';
+import { inArray } from 'drizzle-orm';
+import { db } from '#database';
+import { user } from '#database/schema/authentication';
+import { cohort, cohortTimetableMtm } from '#database/schema/timetable';
+
+const logger = getLogger(['chronos', 'timetable', 'cleanup']);
+
+export type OrphanCleanupSummary = {
+  /** IDs of the deleted cohort rows. */
+  deletedCohortIds: string[];
+  /** Number of users whose cohortId was nullified. */
+  affectedUserCount: number;
+};
+
+/**
+ * Find and delete cohorts that are not linked to any timetable via the
+ * `cohort_timetable_mtm` table.  For each orphan, any user referencing that
+ * cohort has their `cohortId` set to NULL before the cohort row is removed.
+ *
+ * The destructive part of the operation (user nullification + cohort deletion)
+ * runs inside a single database transaction.
+ */
+export async function cleanupOrphanedCohorts(): Promise<OrphanCleanupSummary> {
+  // Find all cohort IDs that are referenced in the MTM table
+  const linkedRows = await db
+    .selectDistinct({ cohortId: cohortTimetableMtm.cohortId })
+    .from(cohortTimetableMtm);
+
+  const linkedSet = new Set(linkedRows.map((r) => r.cohortId));
+
+  // Find all cohort IDs
+  const allCohortRows = await db.select({ id: cohort.id }).from(cohort);
+
+  // Cohorts whose ID does not appear in the MTM table are orphaned
+  const orphanedCohortIds = allCohortRows
+    .map((r) => r.id)
+    .filter((id) => !linkedSet.has(id));
+
+  if (orphanedCohortIds.length === 0) {
+    logger.info('No orphaned cohorts found.');
+    return { affectedUserCount: 0, deletedCohortIds: [] };
+  }
+
+  logger.info('Found orphaned cohorts', { count: orphanedCohortIds.length });
+
+  let affectedUserCount = 0;
+
+  await db.transaction(async (tx) => {
+    // Nullify cohortId on users referencing orphaned cohorts
+    const affectedUsers = await tx
+      .select({ id: user.id })
+      .from(user)
+      .where(inArray(user.cohortId, orphanedCohortIds));
+
+    if (affectedUsers.length > 0) {
+      const userIds = affectedUsers.map((u) => u.id);
+      await tx
+        .update(user)
+        .set({ cohortId: null })
+        .where(inArray(user.id, userIds));
+      affectedUserCount = userIds.length;
+      logger.info('Nullified cohortId for users', { count: userIds.length });
+    }
+
+    // Delete the orphaned cohort rows
+    await tx.delete(cohort).where(inArray(cohort.id, orphanedCohortIds));
+    logger.info('Deleted orphaned cohorts', {
+      count: orphanedCohortIds.length,
+    });
+  });
+
+  return { affectedUserCount, deletedCohortIds: orphanedCohortIds };
+}

--- a/apps/iris/public/locales/en/translation.json
+++ b/apps/iris/public/locales/en/translation.json
@@ -220,6 +220,8 @@
     "currentTimetables": "Current",
     "upcomingTimetables": "Upcoming",
     "clean": "Clean",
+    "cleanupConfirmTitle": "Clean Up Orphaned Cohorts",
+    "cleanupConfirmDescription": "This will delete all cohorts that are no longer linked to any timetable. Users referencing those cohorts will have their cohort assignment removed. This action cannot be undone.",
     "cleanupOrphanedCohortsSuccess": "Orphaned cohorts cleaned up",
     "cleanupOrphanedCohortsError": "Failed to clean up orphaned cohorts"
   },

--- a/apps/iris/public/locales/en/translation.json
+++ b/apps/iris/public/locales/en/translation.json
@@ -218,7 +218,10 @@
     "refresh": "Refresh",
     "totalTimetables": "Total",
     "currentTimetables": "Current",
-    "upcomingTimetables": "Upcoming"
+    "upcomingTimetables": "Upcoming",
+    "clean": "Clean",
+    "cleanupOrphanedCohortsSuccess": "Orphaned cohorts cleaned up",
+    "cleanupOrphanedCohortsError": "Failed to clean up orphaned cohorts"
   },
   "navigation": {
     "title": "Navigation",

--- a/apps/iris/public/locales/hu/translation.json
+++ b/apps/iris/public/locales/hu/translation.json
@@ -208,6 +208,8 @@
     "currentTimetables": "Aktuális",
     "upcomingTimetables": "Közelgő",
     "clean": "Tisztítás",
+    "cleanupConfirmTitle": "Árva csoportok törlése",
+    "cleanupConfirmDescription": "Ez törölni fog minden olyan csoportot, amely már nincs hozzárendelve egyetlen órarendhez sem. Az ilyen csoportokra hivatkozó felhasználók csoport-hozzárendelése törlődik. Ez a művelet nem vonható vissza.",
     "cleanupOrphanedCohortsSuccess": "Árva csoportok kitakarítva",
     "cleanupOrphanedCohortsError": "Nem sikerült az árva csoportok tisztítása"
   },

--- a/apps/iris/public/locales/hu/translation.json
+++ b/apps/iris/public/locales/hu/translation.json
@@ -206,7 +206,10 @@
     "refresh": "Frissítés",
     "totalTimetables": "Összesen",
     "currentTimetables": "Aktuális",
-    "upcomingTimetables": "Közelgő"
+    "upcomingTimetables": "Közelgő",
+    "clean": "Tisztítás",
+    "cleanupOrphanedCohortsSuccess": "Árva csoportok kitakarítva",
+    "cleanupOrphanedCohortsError": "Nem sikerült az árva csoportok tisztítása"
   },
   "common": {
     "cancel": "Mégsem",

--- a/apps/iris/src/routes/_private/admin/timetable/manage.tsx
+++ b/apps/iris/src/routes/_private/admin/timetable/manage.tsx
@@ -156,6 +156,7 @@ function TimetableManagePage() {
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [cleanupDialogOpen, setCleanupDialogOpen] = useState(false);
   const [selectedItem, setSelectedItem] = useState<TimetableRow | null>(null);
   const [itemToDelete, setItemToDelete] = useState<TimetableRow | null>(null);
 
@@ -307,7 +308,7 @@ function TimetableManagePage() {
       <div className="flex flex-wrap items-center gap-4">
         <Button
           disabled={cleanupMutation.isPending}
-          onClick={() => cleanupMutation.mutate()}
+          onClick={() => setCleanupDialogOpen(true)}
           size="sm"
           variant="outline"
         >
@@ -459,6 +460,37 @@ function TimetableManagePage() {
               {deleteMutation.isPending
                 ? t('common.deleting')
                 : t('common.delete')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog onOpenChange={setCleanupDialogOpen} open={cleanupDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('timetable.cleanupConfirmTitle')}</DialogTitle>
+            <DialogDescription>
+              {t('timetable.cleanupConfirmDescription')}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              onClick={() => setCleanupDialogOpen(false)}
+              variant="outline"
+            >
+              {t('common.cancel')}
+            </Button>
+            <Button
+              disabled={cleanupMutation.isPending}
+              onClick={() => {
+                cleanupMutation.mutate();
+                setCleanupDialogOpen(false);
+              }}
+              variant="destructive"
+            >
+              {cleanupMutation.isPending
+                ? t('common.deleting')
+                : t('timetable.clean')}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/iris/src/routes/_private/admin/timetable/manage.tsx
+++ b/apps/iris/src/routes/_private/admin/timetable/manage.tsx
@@ -6,6 +6,7 @@ import {
   Calendar,
   CalendarCheck,
   CalendarClock,
+  Eraser,
   FileUp,
   Pen,
   RefreshCw,
@@ -241,6 +242,26 @@ function TimetableManagePage() {
     },
   });
 
+  const cleanupMutation = useMutation({
+    mutationFn: async () => {
+      const res = await parseResponse(
+        api.timetable.timetables['cleanup-orphaned-cohorts'].$post()
+      );
+      if (!res.success) {
+        throw new Error('Failed to clean up orphaned cohorts');
+      }
+      return res;
+    },
+    onError: () => {
+      toast.error(t('timetable.cleanupOrphanedCohortsError'));
+    },
+    onSuccess: () => {
+      toast.success(t('timetable.cleanupOrphanedCohortsSuccess'));
+      queryClient.invalidateQueries({ queryKey: queryKeys.timetables.all() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.cohorts() });
+    },
+  });
+
   const handleEditSubmit = async (payload: {
     name?: string;
     validFrom?: string;
@@ -284,6 +305,15 @@ function TimetableManagePage() {
       </div>
 
       <div className="flex flex-wrap items-center gap-4">
+        <Button
+          disabled={cleanupMutation.isPending}
+          onClick={() => cleanupMutation.mutate()}
+          size="sm"
+          variant="outline"
+        >
+          <Eraser className="h-4 w-4" />
+          {t('timetable.clean')}
+        </Button>
         <div className="ml-auto flex items-center gap-2">
           <Button onClick={() => timetablesQuery.refetch()} variant="outline">
             <RefreshCw className="h-4 w-4" />


### PR DESCRIPTION
This pull request introduces a new feature to clean up orphaned cohorts—cohorts that are no longer linked to any timetable—and ensures users referencing these cohorts are updated accordingly. It also updates the timetable deletion process to remove orphaned cohorts automatically and adds a dedicated API endpoint for manual cleanup. The documentation for affected endpoints has been improved to reflect these changes.

**Cohort Cleanup Functionality:**

- Added a new utility function `cleanupOrphanedCohorts` in `cleanup.ts` that finds cohorts not linked to any timetable, nullifies `cohortId` for users referencing them, and deletes the orphaned cohorts in a single transaction.
- Introduced a new API endpoint `/timetables/cleanup-orphaned-cohorts` with handler `cleanupOrphanedCohortsHandler` to trigger this cleanup manually; it returns a summary of affected users and deleted cohorts. [[1]](diffhunk://#diff-f1e9dc99724e83d71a6a2d7cb31ff935cd81ae26fa3cb8d8647a7fc1c9f01f01R5) [[2]](diffhunk://#diff-f1e9dc99724e83d71a6a2d7cb31ff935cd81ae26fa3cb8d8647a7fc1c9f01f01R51-R54) [[3]](diffhunk://#diff-aefc77e66fc89eabf7d58bd05e37a8b36fcc03491048fd1611897157d1844c78R521-R564)

**Timetable Deletion Improvements:**

- Updated the timetable deletion logic to also delete any orphaned cohorts as part of the process, ensuring no unused cohorts are left behind.
- Changed the description for timetable deletion and preview endpoints to clarify that orphaned cohorts will be deleted when a timetable is removed. [[1]](diffhunk://#diff-aefc77e66fc89eabf7d58bd05e37a8b36fcc03491048fd1611897157d1844c78L250-R251) [[2]](diffhunk://#diff-aefc77e66fc89eabf7d58bd05e37a8b36fcc03491048fd1611897157d1844c78L377-R382)

closes #200 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “clean up orphaned cohorts” endpoint.
  * Added an admin UI action to trigger orphaned cohort cleanup.
  * Introduced a daily scheduled cleanup job for orphaned cohorts.
  * Added user-facing success/error text for the cleanup action.

* **Improvements**
  * Timetable deletion now removes orphaned cohorts and clears related cohort assignments.
  * Deletion preview messaging now reflects orphaned cohort cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->