### PR TITLE
feat(timetable): enable class color settings for authenticated users

### DIFF
--- a/apps/iris/src/components/timetable/index.tsx
+++ b/apps/iris/src/components/timetable/index.tsx
@@ -139,8 +139,11 @@ export function TimetableView() {
   const navigate = useNavigate({ from: Route.fullPath });
   const queryClient = useQueryClient();
 
-  // Fetch user settings for class colors
+  const isAuthenticated = !isPending && !!session;
+
+  // Fetch user settings for class colors (authenticated users only)
   const settingsQuery = useQuery({
+    enabled: isAuthenticated,
     queryFn: async () => {
       const res = await parseResponse(api.notifications.settings.$get());
       if (!res.success) {
@@ -150,7 +153,9 @@ export function TimetableView() {
     },
     queryKey: queryKeys.notifications.settings(),
   });
-  const userColors = settingsQuery.data?.timetableClassColors ?? {};
+  const userColors = isAuthenticated
+    ? (settingsQuery.data?.timetableClassColors ?? {})
+    : {};
 
   // Mutation to save class color
   const colorMutation = useMutation({
@@ -558,7 +563,7 @@ export function TimetableView() {
         ) : (
           <TimetableGrid
             model={model}
-            onColorChange={handleColorChange}
+            onColorChange={isAuthenticated ? handleColorChange : undefined}
             userColors={userColors}
           />
         )}


### PR DESCRIPTION
This pull request makes improvements to the `TimetableView` component to ensure that class color customization features are only available to authenticated users. The changes prevent unauthenticated users from triggering user settings queries or interacting with class color features.

**Authentication-aware feature gating:**

* Added an `isAuthenticated` check to ensure user settings for class colors are only fetched for authenticated users.
* Updated the logic for `userColors` so that only authenticated users can access their saved class colors; unauthenticated users receive an empty object.
* Modified the `onColorChange` prop for `TimetableGrid` to disable color change functionality for unauthenticated users.

closes #248  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Timetable color preferences now load only for signed-in users.
  * Unauthenticated users no longer see or use timetable color customization controls.
  * The timetable view now falls back to default colors when no user session is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->