### PR TITLE
fix(iris): resolve TypeError on /cards by unwrapping envelope data

### DIFF
--- a/apps/iris/src/routes/_private/cards/index.tsx
+++ b/apps/iris/src/routes/_private/cards/index.tsx
@@ -38,6 +38,7 @@ import { api } from '@/utils/hc';
 import { queryKeys } from '@/utils/query-keys';
 
 type SelfCardsResponse = InferResponseType<typeof api.doorlock.self.cards.$get>;
+type SelfCardsData = NonNullable<SelfCardsResponse['data']>;
 type SelfCard = NonNullable<SelfCardsResponse['data']>['cards'][number];
 
 export const Route = createFileRoute('/_private/cards/')({
@@ -50,12 +51,14 @@ function CardsPage() {
   const [activateCard, setActivateCard] = useState<SelfCard | null>(null);
 
   const {
-    data: cards,
+    data: cardsResponse,
     isLoading,
     isError,
-  } = useApiQuery<SelfCard[]>(() => api.doorlock.self.cards.$get(), {
+  } = useApiQuery<SelfCardsData>(() => api.doorlock.self.cards.$get(), {
     queryKey: queryKeys.doorlock.selfCards(),
   });
+
+  const cards = cardsResponse?.cards;
 
   const freezeMutation = useApiMutation({
     mutationFn: ({ id, frozen }: { id: string; frozen: boolean }) =>


### PR DESCRIPTION
Fixes #260

The `doorlock.self.cards` endpoint returns `{ data: { cards: [...] } }`, but `useApiQuery` only unwraps one envelope level, so the query held the inner object. Typing the query as the full `data` object and accessing `.cards` fixes the `a.map is not a function` error on `/cards`.

Mirrors the established pattern in `admin/doorlock/cards.tsx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading self-cards by handling unavailable API responses more safely.
  * Strengthened response handling to help prevent errors when card data is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->