### PR TITLE
fix(iris): stop app shell from clipping page right edge

### DIFF
--- a/apps/iris/index.html
+++ b/apps/iris/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="overflow-x-hidden" lang="en" >
+<html lang="en" >
   <head>
     <meta charset="UTF-8" />
     <meta content="width=device-width, initial-scale=1.0" name="viewport" />
@@ -13,8 +13,8 @@
     <!-- <link rel="manifest" href="/manifest.json" /> -->
     <title>Filc</title>
   </head>
-  <body class="h-dvh overflow-x-hidden">
-    <div class="h-full flex flex-col overflow-x-hidden" id="app" ></div>
+  <body class="h-dvh">
+    <div class="h-full flex flex-col" id="app" ></div>
     <script src="/src/main.tsx" type="module" ></script>
   </body>
 </html>

--- a/apps/iris/src/components/navbar.tsx
+++ b/apps/iris/src/components/navbar.tsx
@@ -76,8 +76,8 @@ export function Navbar({
   return (
     <>
       <nav className="border-border border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60">
-        <div className="flex h-16 items-center px-6">
-          <div className="flex items-center gap-3">
+        <div className="flex h-16 min-w-0 items-center px-6">
+          <div className="flex min-w-0 items-center gap-3">
             {children}
             {data && showLinks && (
               <Button
@@ -105,7 +105,7 @@ export function Navbar({
                 <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary">
                   <GraduationCap className="h-5 w-5 text-primary-foreground" />
                 </div>
-                <span className="font-semibold text-foreground text-xl">
+                <span className="truncate font-semibold text-foreground text-xl">
                   filc
                 </span>
               </>
@@ -118,7 +118,7 @@ export function Navbar({
             />
           )}
 
-          <div className="ml-auto flex items-center gap-3">
+          <div className="ml-auto flex min-w-0 items-center gap-3">
             {data && <NotificationBell />}
             {data && <BugReportDialog />}
 

--- a/apps/iris/src/components/timetable/index.tsx
+++ b/apps/iris/src/components/timetable/index.tsx
@@ -448,7 +448,7 @@ export function TimetableView() {
 
   return (
     <div className="flex grow flex-col items-center p-4">
-      <div className="flex w-full max-w-7xl flex-col gap-4">
+      <div className="flex w-full min-w-0 max-w-7xl flex-col gap-4">
         <FilterBar
           activeFilter={activeFilter}
           classrooms={classroomsQuery.data}

--- a/apps/iris/src/components/ui/sidebar.tsx
+++ b/apps/iris/src/components/ui/sidebar.tsx
@@ -314,7 +314,7 @@ function SidebarInset({ className, ...props }: ComponentProps<'main'>) {
   return (
     <main
       className={cn(
-        'relative flex w-full flex-1 flex-col bg-background md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm',
+        'relative flex w-full min-w-0 flex-1 flex-col bg-background md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm',
         className
       )}
       data-slot="sidebar-inset"


### PR DESCRIPTION
Fixes #261

Remove the stacked `overflow-x-hidden` from `<html>`, `<body>`, and `#app` in `index.html` that was silently clipping the right side of every page. Add `min-w-0` flex guards to the sidebar inset, navbar row/right cluster, and timetable container so wide content shrinks/scrolls locally instead of forcing overflow.

The timetable grid keeps its own `overflow-x-auto` wrapper for internal horizontal scrolling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive layout behavior to prevent horizontal content overflow.
  * Constrained navigation, timetable, and sidebar areas for more reliable sizing.
  * Long logo text now truncates cleanly instead of extending beyond its available space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->