### PR TITLE
fix(iris): allow bug report submission by fixing validator contract

### DIFF
--- a/apps/iris/src/components/bug-report-dialog.tsx
+++ b/apps/iris/src/components/bug-report-dialog.tsx
@@ -66,14 +66,17 @@ export function BugReportDialog() {
     },
     validators: {
       onSubmit: ({ value }) => {
-        const errors: Record<string, string[]> = {};
+        const errors: { description?: string; subject?: string } = {};
         if (value.subject.trim().length < 3) {
-          errors.subject = [t('bugReport.subjectTooShort')];
+          errors.subject = t('bugReport.subjectTooShort');
         }
         if (value.description.trim().length < 10) {
-          errors.description = [t('bugReport.descriptionTooShort')];
+          errors.description = t('bugReport.descriptionTooShort');
         }
-        return errors;
+        if (Object.keys(errors).length === 0) {
+          return undefined;
+        }
+        return { fields: errors };
       },
     },
   });


### PR DESCRIPTION
Fixes #262

TanStack Form v1 treats any non-`undefined` validator return as a failure, so the always-returned `errors` object blocked `onSubmit` (the API POST) from ever firing — the "Send report" button did nothing.

Now the validator returns `undefined` on valid input (submission proceeds) and the v1 field-error shape `{ fields: {...} }` on invalid input, so per-field errors render via `FieldError`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bug report form validation.
  * Validation messages are now displayed consistently for missing or invalid subject and description fields.
  * Forms without errors no longer show unnecessary validation feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->